### PR TITLE
Add SortingNetworks library with depth-13 networks for 27/28 channels

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # SortingNetworks
-.NET implementation of "Depth-13 Sorting Networks for 28 Channels" https://arxiv.org/abs/2511.04107
+
+A .NET library that uses sorting-network-based specializations for small
+collections. For sizes up to 28, elements are sorted via fixed
+compare-and-swap sequences -- including depth-13 networks for 27 and 28
+channels from the paper
+["Depth-13 Sorting Networks for 28 Channels"](https://arxiv.org/abs/2511.04107).
+Larger inputs fall back to the default .NET sort.
+
+## Usage
+
+```csharp
+using SortingNetworks;
+
+int[] data = { 5, 3, 1, 4, 2 };
+NetworkSort.Sort(data);            // IComparable<T> path
+NetworkSort.Sort(data, comparer);  // IComparer<T> path
+
+Span<int> span = stackalloc int[] { 5, 3, 1, 4, 2 };
+NetworkSort.Sort(span);
+```
+
+## Design
+
+| Input size | Strategy |
+|---|---|
+| 0-1 | No-op |
+| 2-26 | Batcher's odd-even merge sort network |
+| 27-28 | Depth-13 networks from arXiv:2511.04107 |
+| 29+ | Fallback to `Span<T>.Sort()` / `Array.Sort()` |
+
+Sorting networks execute a fixed sequence of compare-and-swap operations
+determined entirely by the input length. This eliminates branches and enables
+predictable performance for small arrays. The 27- and 28-channel networks are
+derived from the paper's reflection-symmetric construction that improved the
+previous best depth bound from 14 to 13.
+
+## Building
+
+```
+dotnet build
+dotnet test
+dotnet run --project SortingNetworks.Benchmarks -c Release -- --filter *
+```
+
+## Projects
+
+- **SortingNetworks** -- class library (future NuGet package)
+- **SortingNetworks.Tests** -- xUnit correctness tests covering lengths 0-64,
+  int/string types, sorted/reversed/duplicate inputs, and the 27/28-element
+  specialized paths
+- **SortingNetworks.Benchmarks** -- BenchmarkDotNet benchmarks comparing
+  `NetworkSort.Sort` vs `Array.Sort` / `Span<T>.Sort` across multiple sizes
+  and input distributions
+
+## Paper reference
+
+> Chengu Wang, "Depth-13 Sorting Networks for 28 Channels", arXiv:2511.04107, 2025.
+>
+> Establishes new depth upper bounds for sorting networks on 27 and 28
+> channels, improving the previous best bound of 14 to 13. The 28-channel
+> network is constructed with reflectional symmetry by combining high-quality
+> prefixes of 16- and 12-channel networks, extending them greedily one
+> comparator at a time, and using a SAT solver to complete the remaining
+> layers.

--- a/SortingNetworks.Benchmarks/Program.cs
+++ b/SortingNetworks.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(SortingNetworks.Benchmarks.SortingBenchmarks).Assembly).Run(args);

--- a/SortingNetworks.Benchmarks/SortingBenchmarks.cs
+++ b/SortingNetworks.Benchmarks/SortingBenchmarks.cs
@@ -1,0 +1,78 @@
+using BenchmarkDotNet.Attributes;
+using SortingNetworks;
+
+namespace SortingNetworks.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class SortingBenchmarks
+{
+    [Params(2, 4, 8, 16, 27, 28, 32, 64)]
+    public int Length { get; set; }
+
+    [ParamsAllValues]
+    public InputKind Kind { get; set; }
+
+    private int[] _source = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _source = Kind switch
+        {
+            InputKind.Random => GenerateRandom(Length, seed: 42),
+            InputKind.Sorted => Enumerable.Range(0, Length).ToArray(),
+            InputKind.Reversed => Enumerable.Range(0, Length).Reverse().ToArray(),
+            InputKind.Duplicates => GenerateDuplicates(Length, seed: 42),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public void ArraySort()
+    {
+        var data = (int[])_source.Clone();
+        Array.Sort(data);
+    }
+
+    [Benchmark]
+    public void SpanSort()
+    {
+        var data = (int[])_source.Clone();
+        data.AsSpan().Sort();
+    }
+
+    [Benchmark]
+    public void NetworkSort_Array()
+    {
+        var data = (int[])_source.Clone();
+        NetworkSort.Sort(data);
+    }
+
+    [Benchmark]
+    public void NetworkSort_Span()
+    {
+        var data = (int[])_source.Clone();
+        NetworkSort.Sort(data.AsSpan());
+    }
+
+    private static int[] GenerateRandom(int length, int seed)
+    {
+        var rng = new Random(seed);
+        return Enumerable.Range(0, length).Select(_ => rng.Next(-1000, 1000)).ToArray();
+    }
+
+    private static int[] GenerateDuplicates(int length, int seed)
+    {
+        var rng = new Random(seed);
+        return Enumerable.Range(0, length).Select(_ => rng.Next(0, 3)).ToArray();
+    }
+}
+
+public enum InputKind
+{
+    Random,
+    Sorted,
+    Reversed,
+    Duplicates
+}

--- a/SortingNetworks.Benchmarks/SortingBenchmarks.cs
+++ b/SortingNetworks.Benchmarks/SortingBenchmarks.cs
@@ -14,6 +14,7 @@ public class SortingBenchmarks
     public InputKind Kind { get; set; }
 
     private int[] _source = null!;
+    private int[] _data = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -26,35 +27,23 @@ public class SortingBenchmarks
             InputKind.Duplicates => GenerateDuplicates(Length, seed: 42),
             _ => throw new ArgumentOutOfRangeException()
         };
+        _data = new int[Length];
     }
+
+    [IterationSetup]
+    public void IterationSetup() => Array.Copy(_source, _data, Length);
 
     [Benchmark(Baseline = true)]
-    public void ArraySort()
-    {
-        var data = (int[])_source.Clone();
-        Array.Sort(data);
-    }
+    public void ArraySort() => Array.Sort(_data);
 
     [Benchmark]
-    public void SpanSort()
-    {
-        var data = (int[])_source.Clone();
-        data.AsSpan().Sort();
-    }
+    public void SpanSort() => _data.AsSpan().Sort();
 
     [Benchmark]
-    public void NetworkSort_Array()
-    {
-        var data = (int[])_source.Clone();
-        NetworkSort.Sort(data);
-    }
+    public void NetworkSort_Array() => NetworkSort.Sort(_data);
 
     [Benchmark]
-    public void NetworkSort_Span()
-    {
-        var data = (int[])_source.Clone();
-        NetworkSort.Sort(data.AsSpan());
-    }
+    public void NetworkSort_Span() => NetworkSort.Sort(_data.AsSpan());
 
     private static int[] GenerateRandom(int length, int seed)
     {

--- a/SortingNetworks.Benchmarks/SortingNetworks.Benchmarks.csproj
+++ b/SortingNetworks.Benchmarks/SortingNetworks.Benchmarks.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SortingNetworks\SortingNetworks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SortingNetworks.Tests/NetworkSortTests.cs
+++ b/SortingNetworks.Tests/NetworkSortTests.cs
@@ -1,0 +1,221 @@
+using Xunit;
+using SortingNetworks;
+
+namespace SortingNetworks.Tests;
+
+public class NetworkSortTests
+{
+    /// <summary>
+    /// Verifies NetworkSort produces the same result as Array.Sort
+    /// for random int arrays of lengths 0 through 64.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_RandomInts_MatchesArraySort(int length)
+    {
+        var rng = new Random(42 + length);
+        var input = Enumerable.Range(0, length).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        var actual = (int[])input.Clone();
+        NetworkSort.Sort(actual);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_Span_RandomInts_MatchesArraySort(int length)
+    {
+        var rng = new Random(42 + length);
+        var input = Enumerable.Range(0, length).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        var actual = (int[])input.Clone();
+        NetworkSort.Sort(actual.AsSpan());
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_WithComparer_RandomInts_MatchesArraySort(int length)
+    {
+        var rng = new Random(42 + length);
+        var input = Enumerable.Range(0, length).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        var actual = (int[])input.Clone();
+        NetworkSort.Sort(actual, Comparer<int>.Default);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_Strings_MatchesArraySort(int length)
+    {
+        var rng = new Random(42 + length);
+        var input = Enumerable.Range(0, length).Select(_ => rng.Next(0, 100).ToString()).ToArray();
+        var expected = (string[])input.Clone();
+        Array.Sort(expected, StringComparer.Ordinal);
+
+        var actual = (string[])input.Clone();
+        NetworkSort.Sort(actual, StringComparer.Ordinal);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_AlreadySorted(int length)
+    {
+        var input = Enumerable.Range(0, length).ToArray();
+        var expected = (int[])input.Clone();
+
+        NetworkSort.Sort(input);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_ReverseSorted(int length)
+    {
+        var input = Enumerable.Range(0, length).Reverse().ToArray();
+        var expected = Enumerable.Range(0, length).ToArray();
+
+        NetworkSort.Sort(input);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_Duplicates(int length)
+    {
+        // All elements are the same value
+        var input = Enumerable.Repeat(7, length).ToArray();
+        var expected = (int[])input.Clone();
+
+        NetworkSort.Sort(input);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void Sort_DuplicateHeavy(int length)
+    {
+        var rng = new Random(42 + length);
+        // Only 3 distinct values to create heavy duplicates
+        var input = Enumerable.Range(0, length).Select(_ => rng.Next(0, 3)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        NetworkSort.Sort(input);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Fact]
+    public void Sort_27Elements_UsesSpecializedNetwork()
+    {
+        // Multiple random seeds to stress the 27-element network
+        for (int seed = 0; seed < 100; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 27).Select(_ => rng.Next(-10000, 10000)).ToArray();
+            var expected = (int[])input.Clone();
+            Array.Sort(expected);
+
+            NetworkSort.Sort(input);
+
+            Assert.Equal(expected, input);
+        }
+    }
+
+    [Fact]
+    public void Sort_28Elements_UsesSpecializedNetwork()
+    {
+        // Multiple random seeds to stress the 28-element network
+        for (int seed = 0; seed < 100; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 28).Select(_ => rng.Next(-10000, 10000)).ToArray();
+            var expected = (int[])input.Clone();
+            Array.Sort(expected);
+
+            NetworkSort.Sort(input);
+
+            Assert.Equal(expected, input);
+        }
+    }
+
+    [Fact]
+    public void Sort_27Elements_Span_WithComparer()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 27).Select(_ => rng.Next(-10000, 10000)).ToArray();
+            var expected = (int[])input.Clone();
+            Array.Sort(expected);
+
+            NetworkSort.Sort(input.AsSpan(), Comparer<int>.Default);
+
+            Assert.Equal(expected, input);
+        }
+    }
+
+    [Fact]
+    public void Sort_28Elements_Span_WithComparer()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 28).Select(_ => rng.Next(-10000, 10000)).ToArray();
+            var expected = (int[])input.Clone();
+            Array.Sort(expected);
+
+            NetworkSort.Sort(input.AsSpan(), Comparer<int>.Default);
+
+            Assert.Equal(expected, input);
+        }
+    }
+
+    [Fact]
+    public void Sort_NullComparer_UsesDefault()
+    {
+        var input = new[] { 3, 1, 2 };
+        NetworkSort.Sort(input, null);
+        Assert.Equal([1, 2, 3], input);
+    }
+
+    [Fact]
+    public void Sort_FallsBackForLargeArrays()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 100).Select(_ => rng.Next()).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        NetworkSort.Sort(input);
+
+        Assert.Equal(expected, input);
+    }
+
+    public static TheoryData<int> Lengths
+    {
+        get
+        {
+            var data = new TheoryData<int>();
+            for (int i = 0; i <= 64; i++)
+                data.Add(i);
+            return data;
+        }
+    }
+}

--- a/SortingNetworks.Tests/SortingNetworks.Tests.csproj
+++ b/SortingNetworks.Tests/SortingNetworks.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SortingNetworks\SortingNetworks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SortingNetworks.sln
+++ b/SortingNetworks.sln
@@ -1,0 +1,31 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SortingNetworks", "SortingNetworks\SortingNetworks.csproj", "{A1B2C3D4-1111-2222-3333-444455556666}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SortingNetworks.Tests", "SortingNetworks.Tests\SortingNetworks.Tests.csproj", "{A1B2C3D4-1111-2222-3333-444455557777}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SortingNetworks.Benchmarks", "SortingNetworks.Benchmarks\SortingNetworks.Benchmarks.csproj", "{A1B2C3D4-1111-2222-3333-444455558888}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-1111-2222-3333-444455556666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556666}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455557777}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455557777}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455557777}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455557777}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455558888}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455558888}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455558888}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455558888}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/SortingNetworks/NetworkData.cs
+++ b/SortingNetworks/NetworkData.cs
@@ -1,0 +1,145 @@
+namespace SortingNetworks;
+
+/// <summary>
+/// Stores pre-computed sorting network comparator sequences.
+/// Networks for sizes 2–26 use Batcher's odd-even merge sort construction.
+/// Networks for sizes 27–28 use the depth-13 networks from the paper
+/// "Depth-13 Sorting Networks for 28 Channels" (arXiv:2511.04107).
+/// </summary>
+internal static class NetworkData
+{
+    internal const int MaxNetworkSize = 28;
+
+    private static readonly int[][] s_networks;
+
+    static NetworkData()
+    {
+        s_networks = new int[MaxNetworkSize + 1][];
+
+        // Generate Batcher's odd-even merge sort networks for sizes 2–26
+        for (int n = 2; n <= 26; n++)
+        {
+            s_networks[n] = GenerateBatcherNetwork(n);
+        }
+
+        // Paper's depth-13 networks for 27 and 28 channels
+        s_networks[27] = GenerateNetwork27();
+        s_networks[28] = Network28;
+    }
+
+    internal static int[] GetNetwork(int n) => s_networks[n];
+
+    #region Batcher's Odd-Even Merge Sort Network Generator
+
+    /// <summary>
+    /// Generates a sorting network using Batcher's odd-even merge sort.
+    /// Pads to the next power of 2 and filters out comparators with indices >= n.
+    /// </summary>
+    private static int[] GenerateBatcherNetwork(int n)
+    {
+        // Find next power of 2
+        int p = 1;
+        while (p < n) p <<= 1;
+
+        var pairs = new List<int>();
+        BatcherSort(0, p - 1, n, pairs);
+        return pairs.ToArray();
+    }
+
+    private static void BatcherSort(int lo, int hi, int n, List<int> pairs)
+    {
+        if (lo >= hi) return;
+        int mid = lo + (hi - lo) / 2;
+        BatcherSort(lo, mid, n, pairs);
+        BatcherSort(mid + 1, hi, n, pairs);
+        BatcherMerge(lo, hi, 1, n, pairs);
+    }
+
+    private static void BatcherMerge(int lo, int hi, int step, int n, List<int> pairs)
+    {
+        int doubleStep = step * 2;
+        if (doubleStep > hi - lo)
+        {
+            // Base case: single comparator
+            if (lo < n && lo + step < n)
+            {
+                pairs.Add(lo);
+                pairs.Add(lo + step);
+            }
+            return;
+        }
+
+        BatcherMerge(lo, hi, doubleStep, n, pairs);
+        BatcherMerge(lo + step, hi, doubleStep, n, pairs);
+
+        for (int i = lo + step; i + step <= hi; i += doubleStep)
+        {
+            if (i < n && i + step < n)
+            {
+                pairs.Add(i);
+                pairs.Add(i + step);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Paper's 28-Channel Depth-13 Sorting Network
+
+    /// <summary>
+    /// The 28-channel depth-13 sorting network from
+    /// "Depth-13 Sorting Networks for 28 Channels" (arXiv:2511.04107).
+    /// Flattened comparator pairs: [i0, j0, i1, j1, ...].
+    /// </summary>
+    private static readonly int[] Network28 =
+    [
+        // Layer 1
+        0,27, 1,26, 2,25, 3,24, 4,23, 5,22, 6,21, 7,20, 8,9, 10,11, 12,15, 13,14, 16,17, 18,19,
+        // Layer 2
+        0,1, 2,3, 4,5, 6,7, 8,10, 9,11, 12,14, 13,15, 16,18, 17,19, 20,21, 22,23, 24,25, 26,27,
+        // Layer 3
+        0,2, 1,3, 4,6, 5,7, 8,19, 9,12, 10,14, 11,16, 13,17, 15,18, 20,22, 21,23, 24,26, 25,27,
+        // Layer 4
+        0,4, 1,5, 2,20, 3,21, 6,24, 7,25, 8,13, 9,11, 10,17, 12,15, 14,19, 16,18, 22,26, 23,27,
+        // Layer 5
+        1,2, 3,24, 4,6, 5,22, 7,20, 8,9, 10,12, 11,13, 14,16, 15,17, 18,19, 21,23, 25,26,
+        // Layer 6
+        0,8, 1,4, 2,6, 3,9, 5,7, 10,11, 12,13, 14,15, 16,17, 18,24, 19,27, 20,22, 21,25, 23,26,
+        // Layer 7
+        1,10, 2,13, 4,8, 5,12, 6,9, 7,20, 14,25, 15,22, 17,26, 18,21, 19,23,
+        // Layer 8
+        3,4, 6,14, 7,11, 8,15, 9,17, 10,18, 12,19, 13,21, 16,20, 23,24,
+        // Layer 9
+        2,4, 5,6, 7,8, 9,13, 11,15, 12,16, 14,18, 19,20, 21,22, 23,25,
+        // Layer 10
+        2,7, 4,8, 6,10, 9,11, 12,14, 13,15, 16,18, 17,21, 19,23, 20,25,
+        // Layer 11
+        1,3, 4,7, 5,6, 8,9, 10,12, 11,16, 13,14, 15,17, 18,19, 20,23, 21,22, 24,26,
+        // Layer 12
+        2,3, 4,5, 6,7, 8,10, 9,12, 11,13, 14,16, 15,18, 17,19, 20,21, 22,23, 24,25,
+        // Layer 13
+        3,4, 5,6, 7,8, 9,10, 11,12, 13,14, 15,16, 17,18, 19,20, 21,22, 23,24,
+    ];
+
+    /// <summary>
+    /// Derives the 27-channel network from the 28-channel network
+    /// by removing all comparators that involve channel 27.
+    /// </summary>
+    private static int[] GenerateNetwork27()
+    {
+        var pairs = new List<int>(Network28.Length);
+        for (int i = 0; i < Network28.Length; i += 2)
+        {
+            int a = Network28[i];
+            int b = Network28[i + 1];
+            if (a < 27 && b < 27)
+            {
+                pairs.Add(a);
+                pairs.Add(b);
+            }
+        }
+        return pairs.ToArray();
+    }
+
+    #endregion
+}

--- a/SortingNetworks/NetworkSort.cs
+++ b/SortingNetworks/NetworkSort.cs
@@ -1,0 +1,96 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace SortingNetworks;
+
+/// <summary>
+/// Provides sorting-network-based sorting for small collections.
+/// Uses fixed compare-and-swap networks for sizes up to 28, including
+/// depth-13 networks for 27 and 28 channels from arXiv:2511.04107.
+/// Falls back to the default .NET sort for larger inputs.
+/// </summary>
+public static class NetworkSort
+{
+    /// <summary>
+    /// Sorts the elements of a span using a sorting network when possible.
+    /// </summary>
+    public static void Sort<T>(Span<T> span) where T : IComparable<T>
+    {
+        int n = span.Length;
+        if (n <= 1) return;
+
+        if (n <= NetworkData.MaxNetworkSize)
+        {
+            ApplyNetwork(span, NetworkData.GetNetwork(n));
+            return;
+        }
+
+        span.Sort();
+    }
+
+    /// <summary>
+    /// Sorts the elements of a span using a sorting network when possible,
+    /// with a custom comparer.
+    /// </summary>
+    public static void Sort<T>(Span<T> span, IComparer<T>? comparer)
+    {
+        comparer ??= Comparer<T>.Default;
+        int n = span.Length;
+        if (n <= 1) return;
+
+        if (n <= NetworkData.MaxNetworkSize)
+        {
+            ApplyNetworkWithComparer(span, NetworkData.GetNetwork(n), comparer);
+            return;
+        }
+
+        span.Sort(comparer.Compare);
+    }
+
+    /// <summary>
+    /// Sorts an array using a sorting network when possible.
+    /// </summary>
+    public static void Sort<T>(T[] array) where T : IComparable<T>
+        => Sort(array.AsSpan());
+
+    /// <summary>
+    /// Sorts an array using a sorting network when possible,
+    /// with a custom comparer.
+    /// </summary>
+    public static void Sort<T>(T[] array, IComparer<T>? comparer)
+        => Sort(array.AsSpan(), comparer);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ApplyNetwork<T>(Span<T> span, int[] network) where T : IComparable<T>
+    {
+        ref T first = ref MemoryMarshal.GetReference(span);
+        for (int i = 0; i < network.Length; i += 2)
+        {
+            ref T a = ref Unsafe.Add(ref first, network[i]);
+            ref T b = ref Unsafe.Add(ref first, network[i + 1]);
+            if (a.CompareTo(b) > 0)
+            {
+                T temp = a;
+                a = b;
+                b = temp;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ApplyNetworkWithComparer<T>(Span<T> span, int[] network, IComparer<T> comparer)
+    {
+        ref T first = ref MemoryMarshal.GetReference(span);
+        for (int i = 0; i < network.Length; i += 2)
+        {
+            ref T a = ref Unsafe.Add(ref first, network[i]);
+            ref T b = ref Unsafe.Add(ref first, network[i + 1]);
+            if (comparer.Compare(a, b) > 0)
+            {
+                T temp = a;
+                a = b;
+                b = temp;
+            }
+        }
+    }
+}

--- a/SortingNetworks/SortingNetworks.csproj
+++ b/SortingNetworks/SortingNetworks.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>SortingNetworks</PackageId>
+    <Description>Sorting-network-based specializations for small arrays, including depth-13 networks for 27 and 28 channels from arXiv:2511.04107.</Description>
+    <Authors>Jonathan Peppers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/jonathanpeppers/SortingNetworks</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/jonathanpeppers/SortingNetworks</RepositoryUrl>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Sorting small arrays with a general-purpose O(n log n) algorithm leaves performance on the table -- a fixed compare-and-swap sequence determined at compile time eliminates branches and is predictably fast. This PR introduces a `NetworkSort` class that dispatches by input length to pre-computed sorting networks, falling back to .NET's built-in sort for larger inputs.

## Approach

`NetworkSort.Sort<T>` checks the span/array length and applies:

| Size | Strategy |
|---|---|
| 0-1 | No-op |
| 2-26 | Batcher's odd-even merge sort network (generated once at static init) |
| 27-28 | Depth-13 networks from [arXiv:2511.04107](https://arxiv.org/abs/2511.04107) |
| 29+ | Fallback to `Span<T>.Sort()` |

The 28-channel network is transcribed directly from the paper's Figure 2 (13 layers of comparator pairs). The 27-channel network is derived by removing all comparators involving channel 27 -- valid because fixing a channel to infinity makes those comparators no-ops.

The hot loop uses `Unsafe.Add` with `MemoryMarshal.GetReference` to skip bounds checks when applying the network.

## What's included

- **SortingNetworks** -- class library with `NetworkSort` (4 overloads: `Span<T>` / `T[]`, with/without `IComparer<T>`)
- **SortingNetworks.Tests** -- 526 xUnit tests covering lengths 0-64, `int`/`string` types, sorted/reversed/duplicate inputs, null comparer, large-array fallback, and dedicated 27/28-element stress tests (100 random seeds each)
- **SortingNetworks.Benchmarks** -- BenchmarkDotNet benchmarks comparing `NetworkSort` vs `Array.Sort` / `Span<T>.Sort` across lengths 2, 4, 8, 16, 27, 28, 32, 64 with random/sorted/reversed/duplicate inputs
- Updated **README** with usage, design table, build instructions, and paper reference

All projects target `net10.0`.