### PR TITLE
Remove benchmark sizes 32 and 64

### DIFF
--- a/SortingNetworks.Benchmarks/SortingBenchmarks.cs
+++ b/SortingNetworks.Benchmarks/SortingBenchmarks.cs
@@ -9,7 +9,7 @@ public class SortingBenchmarks
 {
     private const int OpsPerInvoke = 1000;
 
-    [Params(2, 4, 8, 16, 27, 28, 32, 64)]
+    [Params(2, 4, 8, 16, 27, 28)]
     public int Length { get; set; }
 
     [ParamsAllValues]


### PR DESCRIPTION
These sizes exceed `MaxNetworkSize` (28), so `NetworkSort.Sort` just falls back to `Span<T>.Sort()`. Benchmarking them only compares `Array.Sort` vs `Span.Sort` vs the same `Span.Sort` wrapped in `NetworkSort` — nothing unique to this library is measured.

Keeps only sizes where the sorting network is actually exercised: `2, 4, 8, 16, 27, 28`.