### PR TITLE
Update README example to use a 27-length array

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ All other sizes fall back to the default .NET sort.
 ```csharp
 using SortingNetworks;
 
+// Length 27 uses a depth-13 sorting network
 int[] data = {
     27, 26, 25, 24, 23, 22, 21, 20, 19,
     18, 17, 16, 15, 14, 13, 12, 11, 10,

--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ All other sizes fall back to the default .NET sort.
 ```csharp
 using SortingNetworks;
 
-int[] data = { 5, 3, 1, 4, 2 };
+int[] data = {
+    27, 26, 25, 24, 23, 22, 21, 20, 19,
+    18, 17, 16, 15, 14, 13, 12, 11, 10,
+     9,  8,  7,  6,  5,  4,  3,  2,  1,
+};
 NetworkSort.Sort(data);
 NetworkSort.Sort(data, comparer);  // IComparer<int> path
 
-Span<int> span = stackalloc int[] { 5, 3, 1, 4, 2 };
+Span<int> span = stackalloc int[] {
+    27, 26, 25, 24, 23, 22, 21, 20, 19,
+    18, 17, 16, 15, 14, 13, 12, 11, 10,
+     9,  8,  7,  6,  5,  4,  3,  2,  1,
+};
 NetworkSort.Sort(span);
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ int[] data = {
 NetworkSort.Sort(data);
 NetworkSort.Sort(data, comparer);  // IComparer<int> path
 
+// Length 27 uses a depth-13 sorting network
 Span<int> span = stackalloc int[] {
     27, 26, 25, 24, 23, 22, 21, 20, 19,
     18, 17, 16, 15, 14, 13, 12, 11, 10,


### PR DESCRIPTION
The library specializes in sorting arrays of sizes 27 and 28, but the README usage example showed a trivial 5-element array that would just fall back to the default .NET sort. This updates both examples (array and span) to use 27-element arrays so readers immediately see the intended use case.

Also adds a comment above each array noting that the length is significant -- it triggers the depth-13 sorting network path.