### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Pack
+        run: dotnet pack -bl:pack.binlog
+
+      - name: Test
+        run: dotnet test --no-build
+
+      - name: Benchmarks
+        run: |
+          dotnet run --project SortingNetworks.Benchmarks -c Release -- --filter '*'
+          cat BenchmarkDotNet.Artifacts/results/*-report-github.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: packages
+          path: |
+            **/*.nupkg
+            **/*.binlog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Pack
-        run: dotnet pack -bl:pack.binlog
+        run: dotnet pack -c Release -bl:pack.binlog
 
       - name: Test
-        run: dotnet test --no-build
+        run: dotnet test -c Release --no-build
 
       - name: Benchmarks
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -30,7 +30,7 @@ jobs:
           cat BenchmarkDotNet.Artifacts/results/*-report-github.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Pack
         run: dotnet pack -bl:pack.binlog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Build
+        run: dotnet build -c Release -bl:build.binlog
+
       - name: Pack
-        run: dotnet pack -c Release -bl:pack.binlog
+        run: dotnet pack -c Release --no-build
 
       - name: Test
         run: dotnet test -c Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Benchmarks
         run: |
-          dotnet run --project SortingNetworks.Benchmarks -c Release -- --filter '*'
+          dotnet run --project SortingNetworks.Benchmarks -c Release -- --filter '*' --exporters GitHub
           cat BenchmarkDotNet.Artifacts/results/*-report-github.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload artifacts

--- a/SortingNetworks.Benchmarks/SortingNetworks.Benchmarks.csproj
+++ b/SortingNetworks.Benchmarks/SortingNetworks.Benchmarks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SortingNetworks.Tests/NetworkSortTests.cs
+++ b/SortingNetworks.Tests/NetworkSortTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using SortingNetworks;
 
 namespace SortingNetworks.Tests;

--- a/SortingNetworks.Tests/SortingNetworks.Tests.csproj
+++ b/SortingNetworks.Tests/SortingNetworks.Tests.csproj
@@ -2,14 +2,16 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <UseMicrosoftTestingPlatform>true</UseMicrosoftTestingPlatform>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SortingNetworks.Tests/SortingNetworks.Tests.csproj
+++ b/SortingNetworks.Tests/SortingNetworks.Tests.csproj
@@ -2,20 +2,21 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SortingNetworks\SortingNetworks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/SortingNetworks.Tests/SortingNetworks.Tests.csproj
+++ b/SortingNetworks.Tests/SortingNetworks.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatform>true</UseMicrosoftTestingPlatform>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This repo has no CI -- this PR adds a GitHub Actions workflow so that builds, tests, and benchmarks run automatically on pushes and PRs to `main`.

## Approach

A single `ci.yml` workflow with four steps:

- **Pack** -- `dotnet pack -bl:pack.binlog` builds the solution and produces the NuGet package
- **Test** -- `dotnet test --no-build` runs xUnit tests against the already-built output
- **Benchmarks** -- runs BenchmarkDotNet with `--exporters GitHub` and appends the GitHub-flavored markdown table to `$GITHUB_STEP_SUMMARY`, so results are visible directly on the workflow run
- **Artifacts** -- uploads `*.nupkg` and `*.binlog` files with `if: always()` so they are available even when a prior step fails

Uses the latest action versions: checkout@v6, setup-dotnet@v5, upload-artifact@v7.