### PR TITLE
Move tests to fan-out lanes across OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Pack
         run: dotnet pack -c Release --no-build
 
-      - name: Test
-        run: dotnet test -c Release --no-build
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         if: always()
@@ -36,7 +33,8 @@ jobs:
             **/*.nupkg
             **/*.binlog
 
-  benchmark:
+  test-and-benchmark:
+    name: test & benchmark (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -50,6 +48,9 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
+
+      - name: Test
+        run: dotnet test -c Release
 
       - name: Benchmarks
         shell: bash
@@ -76,7 +77,7 @@ jobs:
           if-no-files-found: ignore
 
   summarize:
-    needs: [benchmark]
+    needs: [test-and-benchmark]
     runs-on: ubuntu-latest
     if: always()
 


### PR DESCRIPTION
Tests previously ran only on `ubuntu-latest` inside the `build` job. This means platform-specific issues on Windows or macOS (e.g., SIMD codegen differences, endianness, or runtime behavior) would go undetected until someone ran them locally.

This PR moves the `dotnet test` step into the matrix job that already fans out across `ubuntu-latest`, `windows-latest`, and `macos-latest`, so every PR validates correctness on all three platforms.

**Changes:**

- Removed the `Test` step from the `build` job (which remains build + pack + artifact upload only).
- Added a `Test` step to the fan-out matrix job, running before benchmarks.
- Renamed the job from `benchmark` to `test-and-benchmark` (display name: `test & benchmark (<os>)`) to reflect its expanded scope.
- Updated the `summarize` job's `needs` to reference the new job ID.