### PR TITLE
Add AVX-512F SIMD paths for int/uint/float (32-bit types)

### DIFF
--- a/.github/instructions/performance.instructions.md
+++ b/.github/instructions/performance.instructions.md
@@ -11,6 +11,7 @@ This is a high-performance sorting library. All code in the hot path must follow
 - Mark hot-path private methods with `[MethodImpl(MethodImplOptions.AggressiveInlining)]`.
 - Avoid heap allocations in sort methods — no LINQ, no closures, no boxing.
 - Use inline compare-and-swap (`if (a > b) { T temp = a; a = b; b = temp; }`) for primitive types rather than `IComparer<T>`.
+- **NaN is not supported** for `float`/`double` sorting. Sorting networks use ordered comparisons where `NaN > x` is always false, so NaN values disrupt sort order. See [#10](https://github.com/jonathanpeppers/SortingNetworks/issues/10) and [#11](https://github.com/jonathanpeppers/SortingNetworks/issues/11).
 - `IComparer<T>` overloads use the loop-based `ApplyNetworkWithComparer` path and are not unrolled.
 - Fallback to `span.Sort()` or `Array.Sort()` for sizes outside the network range.
 - `AllowUnsafeBlocks` is enabled in the project.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -12,4 +12,5 @@ applyTo: "SortingNetworks.Tests/**/*.cs"
 - Cover all primitive types: `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `nint`, `nuint`, `char`, `float`, `double`.
 - Cover `string` sorting with explicit `StringComparer.Ordinal`.
 - Include edge-case tests: already sorted, reverse sorted, all duplicates, duplicate-heavy, null array, null comparer, fallback for large arrays.
+- **Do not add NaN tests** for `float`/`double`. NaN is unsupported with sorting networks — see [#10](https://github.com/jonathanpeppers/SortingNetworks/issues/10) and [#11](https://github.com/jonathanpeppers/SortingNetworks/issues/11).
 - Use deterministic `Random` seeds (`new Random(42 + length)` or `new Random(seed)`) for reproducibility.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ individual scalar compare-and-swap branches.
 For `int` and `uint`, AVX2 SIMD is used on x86 with four `Vector256<int>`
 registers (8 elements each). Cross-vector shuffles use `PermuteVar8x32` with
 `Blend` composition, and `Min`/`Max` handles signed and unsigned comparisons.
+On CPUs with AVX-512F, an AVX-512F path uses two `Vector512<int>` registers
+(16 elements each) with `PermuteVar16x32x2` cross-vector shuffles.
 
 For `short`, `ushort`, and `char` (16-bit types), AVX-512 SIMD is used on x86
 when available, packing all elements into a single `Vector512<ushort>`. On
@@ -89,6 +91,8 @@ elements 0-15 are in Table A and elements 16-27 are in Table B, with
 For `float`, AVX2 SIMD is used on x86 with four `Vector256<float>` registers
 (8 elements each). Cross-vector shuffles use `PermuteVar8x32` with
 `BlendVariable` composition, and `Avx.Min`/`Avx.Max` handles comparisons.
+On CPUs with AVX-512F, an AVX-512F path uses two `Vector512<float>` registers
+(16 elements each) with `PermuteVar16x32x2` cross-vector shuffles.
 
 For `double`, AVX-512F SIMD is used on x86 when available (four `Vector512`
 registers). On CPUs without AVX-512F, an AVX2 fallback uses seven
@@ -144,7 +148,7 @@ sorting network dominates:
 | nint | 1,408 ns | 105 ns | **13x** |
 | nuint | 1,381 ns | 103 ns | **13x** |
 
-> **Note:** On processors with AVX-512, `short`, `ushort`, and `char` use AVX-512BW SIMD, and `long` uses AVX-512F SIMD for even greater speedups.
+> **Note:** On processors with AVX-512, `short`, `ushort`, and `char` use AVX-512BW SIMD, `long` uses AVX-512F SIMD, and `int`, `uint`, and `float` use AVX-512F SIMD for even greater speedups.
 
 #### Types where Array.Sort is already SIMD-optimized
 
@@ -166,6 +170,23 @@ unrolled network, avoiding `IComparer<T>` interface dispatch overhead:
 | Type | ArraySort (27) | NetworkSort (27) | Speedup |
 |---|---|---|---|
 | string | 986 ns | 532 ns | **1.9x** |
+
+### x86 AVX-512F (AMD EPYC 9V74, GitHub Actions)
+
+On CPUs with AVX-512F (e.g., AMD EPYC, Intel Ice Lake+), `int`, `uint`, and
+`float` use two `Vector512` registers with `PermuteVar16x32x2` cross-vector
+shuffles:
+
+| Type | ArraySort (27) | NetworkSort (27) | Speedup |
+|---|---|---|---|
+| int | 105 ns | 67 ns | **1.6x** |
+| uint | 122 ns | 63 ns | **1.9x** |
+| float | 2,330 ns | 92 ns | **25x** |
+
+> **Note:** These results are from an AMD EPYC 9V74 on GitHub Actions
+> (ubuntu-latest), which double-pumps 512-bit operations through 256-bit
+> execution ports. Intel CPUs with native 512-bit execution units (e.g.,
+> Sapphire Rapids) may see additional gains.
 
 ### ARM64 (Apple M1, AdvSimd/NEON)
 

--- a/SortingNetworks/NetworkSort.Simd.cs
+++ b/SortingNetworks/NetworkSort.Simd.cs
@@ -2914,10 +2914,8 @@ public static partial class NetworkSort
             vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
 
             // Store results
-        var upper = vec1.GetUpper();
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
-            Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+            Sse2.ShiftLeftLogical128BitLane(vec1.GetUpper().GetLower(), 4));
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
     }
@@ -3065,8 +3063,7 @@ public static partial class NetworkSort
             vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
 
             // Store results
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
     }
@@ -3215,10 +3212,8 @@ public static partial class NetworkSort
             vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
 
             // Store results
-        var upper = vec1.GetUpper();
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
-            Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+            Sse2.ShiftLeftLogical128BitLane(vec1.GetUpper().GetLower(), 4));
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
     }
@@ -3366,8 +3361,7 @@ public static partial class NetworkSort
             vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
 
             // Store results
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
     }
@@ -3516,10 +3510,8 @@ public static partial class NetworkSort
             vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
 
             // Store results
-        var upper = vec1.GetUpper();
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
-            Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+            Sse2.ShiftLeftLogical128BitLane(vec1.GetUpper().GetLower(), 4));
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
     }
@@ -3667,8 +3659,7 @@ public static partial class NetworkSort
             vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
 
             // Store results
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
-        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
         Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
     }

--- a/SortingNetworks/NetworkSort.Simd.cs
+++ b/SortingNetworks/NetworkSort.Simd.cs
@@ -2770,6 +2770,909 @@ public static partial class NetworkSort
         v0.AsByte().StoreUnsafe(ref first);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void SortSimd27_512_int(Span<int> span)
+    {
+        ref int first = ref MemoryMarshal.GetReference(span);
+
+        // Load: vec0 = elements [0..15], vec1 = elements [16..26] padded with int.MaxValue
+        var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+        var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+        var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+        var lastThree = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)));
+        var q2 = Sse2.ShiftRightLogical128BitLane(lastThree, 4);
+        var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+
+            // Step 0
+            var s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 26, 25, 24, 23, 22, 21, 20, 9, 8, 11, 10, 15, 14, 13, 12), vec1);
+            var s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 19, 18, 7, 6, 5, 4, 3, 2, 1, 27, 28, 29, 30, 31), vec1);
+            var min0 = Avx512F.Min(vec0, s0);
+            var max0 = Avx512F.Max(vec0, s0);
+            var min1 = Avx512F.Min(vec1, s1);
+            var max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 1
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(1, 0, 3, 2, 5, 4, 7, 6, 10, 11, 8, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 19, 16, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, 0, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 2
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(2, 3, 0, 1, 6, 7, 4, 5, 19, 12, 14, 16, 9, 17, 10, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 13, 15, 8, 22, 23, 20, 21, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, -1, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 3
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(4, 5, 20, 21, 0, 1, 24, 25, 13, 11, 17, 9, 15, 8, 19, 12), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 10, 16, 14, 2, 3, 26, 23, 6, 7, 22, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 4
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 2, 1, 24, 6, 22, 4, 20, 9, 8, 12, 13, 10, 11, 16, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 15, 19, 18, 7, 23, 5, 21, 3, 26, 25, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, -1, 0, -1, -1, -1, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 5
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(8, 4, 6, 9, 1, 7, 2, 5, 0, 3, 11, 10, 13, 12, 15, 14), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 24, 19, 22, 25, 20, 26, 18, 21, 23, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, 0, 0, 0, -1, 0, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 6
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 10, 13, 3, 8, 12, 9, 20, 4, 6, 1, 11, 5, 2, 25, 22), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(16, 26, 21, 23, 7, 18, 15, 19, 24, 14, 17, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 7
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 5, 14, 11, 15, 17, 18, 7, 19, 21, 6, 8), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(20, 9, 10, 12, 16, 13, 22, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 8
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 4, 3, 2, 6, 5, 8, 7, 13, 10, 15, 16, 9, 18, 11), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(12, 17, 14, 20, 19, 22, 21, 25, 24, 23, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 9
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 7, 3, 8, 5, 10, 2, 4, 11, 6, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 21, 16, 23, 25, 17, 22, 19, 24, 20, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 10
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 3, 2, 1, 7, 6, 5, 4, 9, 8, 12, 16, 10, 14, 13, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 15, 19, 18, 23, 22, 21, 20, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, 0, -1, -1, 0, -1, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 11
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 3, 2, 5, 4, 7, 6, 10, 12, 8, 13, 9, 11, 16, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 19, 15, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 12
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(15, 18, 17, 20, 19, 22, 21, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Store results
+        var upper = vec1.GetUpper();
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
+            Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void SortSimd28_512_int(Span<int> span)
+    {
+        ref int first = ref MemoryMarshal.GetReference(span);
+
+        // Load: vec0 = elements [0..15], vec1 = elements [16..27] padded with int.MaxValue
+        var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+        var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+        var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+        var q2 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)));
+        var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+
+            // Step 0
+            var s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(27, 26, 25, 24, 23, 22, 21, 20, 9, 8, 11, 10, 15, 14, 13, 12), vec1);
+            var s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 19, 18, 7, 6, 5, 4, 3, 2, 1, 0, 28, 29, 30, 31), vec1);
+            var min0 = Avx512F.Min(vec0, s0);
+            var max0 = Avx512F.Max(vec0, s0);
+            var min1 = Avx512F.Min(vec1, s1);
+            var max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 1
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(1, 0, 3, 2, 5, 4, 7, 6, 10, 11, 8, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 19, 16, 17, 21, 20, 23, 22, 25, 24, 27, 26, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, 0, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 2
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(2, 3, 0, 1, 6, 7, 4, 5, 19, 12, 14, 16, 9, 17, 10, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 13, 15, 8, 22, 23, 20, 21, 26, 27, 24, 25, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, -1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 3
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(4, 5, 20, 21, 0, 1, 24, 25, 13, 11, 17, 9, 15, 8, 19, 12), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 10, 16, 14, 2, 3, 26, 27, 6, 7, 22, 23, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 4
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 2, 1, 24, 6, 22, 4, 20, 9, 8, 12, 13, 10, 11, 16, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 15, 19, 18, 7, 23, 5, 21, 3, 26, 25, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, -1, 0, -1, -1, -1, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 5
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(8, 4, 6, 9, 1, 7, 2, 5, 0, 3, 11, 10, 13, 12, 15, 14), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 24, 27, 22, 25, 20, 26, 18, 21, 23, 19, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 6
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 10, 13, 3, 8, 12, 9, 20, 4, 6, 1, 11, 5, 2, 25, 22), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(16, 26, 21, 23, 7, 18, 15, 19, 24, 14, 17, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 7
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 5, 14, 11, 15, 17, 18, 7, 19, 21, 6, 8), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(20, 9, 10, 12, 16, 13, 22, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 8
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 4, 3, 2, 6, 5, 8, 7, 13, 10, 15, 16, 9, 18, 11), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(12, 17, 14, 20, 19, 22, 21, 25, 24, 23, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 9
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 7, 3, 8, 5, 10, 2, 4, 11, 6, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 21, 16, 23, 25, 17, 22, 19, 24, 20, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 10
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 3, 2, 1, 7, 6, 5, 4, 9, 8, 12, 16, 10, 14, 13, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 15, 19, 18, 23, 22, 21, 20, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, 0, -1, -1, 0, -1, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 11
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 3, 2, 5, 4, 7, 6, 10, 12, 8, 13, 9, 11, 16, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 19, 15, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 12
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(15, 18, 17, 20, 19, 22, 21, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0, s0);
+            max0 = Avx512F.Max(vec0, s0);
+            min1 = Avx512F.Min(vec1, s1);
+            max1 = Avx512F.Max(vec1, s1);
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Store results
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void SortSimd27_512_uint(Span<uint> span)
+    {
+        ref int first = ref Unsafe.As<uint, int>(ref MemoryMarshal.GetReference(span));
+
+        // Load: vec0 = elements [0..15], vec1 = elements [16..26] padded with int.MaxValue
+        var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+        var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+        var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+        var lastThree = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)));
+        var q2 = Sse2.ShiftRightLogical128BitLane(lastThree, 4);
+        var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+
+            // Step 0
+            var s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 26, 25, 24, 23, 22, 21, 20, 9, 8, 11, 10, 15, 14, 13, 12), vec1);
+            var s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 19, 18, 7, 6, 5, 4, 3, 2, 1, 27, 28, 29, 30, 31), vec1);
+            var min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            var max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            var min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            var max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 1
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(1, 0, 3, 2, 5, 4, 7, 6, 10, 11, 8, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 19, 16, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, 0, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 2
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(2, 3, 0, 1, 6, 7, 4, 5, 19, 12, 14, 16, 9, 17, 10, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 13, 15, 8, 22, 23, 20, 21, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, -1, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 3
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(4, 5, 20, 21, 0, 1, 24, 25, 13, 11, 17, 9, 15, 8, 19, 12), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 10, 16, 14, 2, 3, 26, 23, 6, 7, 22, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 4
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 2, 1, 24, 6, 22, 4, 20, 9, 8, 12, 13, 10, 11, 16, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 15, 19, 18, 7, 23, 5, 21, 3, 26, 25, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, -1, 0, -1, -1, -1, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 5
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(8, 4, 6, 9, 1, 7, 2, 5, 0, 3, 11, 10, 13, 12, 15, 14), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 24, 19, 22, 25, 20, 26, 18, 21, 23, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, 0, 0, 0, -1, 0, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 6
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 10, 13, 3, 8, 12, 9, 20, 4, 6, 1, 11, 5, 2, 25, 22), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(16, 26, 21, 23, 7, 18, 15, 19, 24, 14, 17, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 7
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 5, 14, 11, 15, 17, 18, 7, 19, 21, 6, 8), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(20, 9, 10, 12, 16, 13, 22, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 8
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 4, 3, 2, 6, 5, 8, 7, 13, 10, 15, 16, 9, 18, 11), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(12, 17, 14, 20, 19, 22, 21, 25, 24, 23, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 9
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 7, 3, 8, 5, 10, 2, 4, 11, 6, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 21, 16, 23, 25, 17, 22, 19, 24, 20, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 10
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 3, 2, 1, 7, 6, 5, 4, 9, 8, 12, 16, 10, 14, 13, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 15, 19, 18, 23, 22, 21, 20, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, 0, -1, -1, 0, -1, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 11
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 3, 2, 5, 4, 7, 6, 10, 12, 8, 13, 9, 11, 16, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 19, 15, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 12
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(15, 18, 17, 20, 19, 22, 21, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Store results
+        var upper = vec1.GetUpper();
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
+            Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void SortSimd28_512_uint(Span<uint> span)
+    {
+        ref int first = ref Unsafe.As<uint, int>(ref MemoryMarshal.GetReference(span));
+
+        // Load: vec0 = elements [0..15], vec1 = elements [16..27] padded with int.MaxValue
+        var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+        var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+        var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+        var q2 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)));
+        var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+
+            // Step 0
+            var s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(27, 26, 25, 24, 23, 22, 21, 20, 9, 8, 11, 10, 15, 14, 13, 12), vec1);
+            var s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 19, 18, 7, 6, 5, 4, 3, 2, 1, 0, 28, 29, 30, 31), vec1);
+            var min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            var max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            var min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            var max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 1
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(1, 0, 3, 2, 5, 4, 7, 6, 10, 11, 8, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 19, 16, 17, 21, 20, 23, 22, 25, 24, 27, 26, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, 0, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 2
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(2, 3, 0, 1, 6, 7, 4, 5, 19, 12, 14, 16, 9, 17, 10, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 13, 15, 8, 22, 23, 20, 21, 26, 27, 24, 25, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, -1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 3
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(4, 5, 20, 21, 0, 1, 24, 25, 13, 11, 17, 9, 15, 8, 19, 12), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 10, 16, 14, 2, 3, 26, 27, 6, 7, 22, 23, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 4
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 2, 1, 24, 6, 22, 4, 20, 9, 8, 12, 13, 10, 11, 16, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 15, 19, 18, 7, 23, 5, 21, 3, 26, 25, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, -1, 0, -1, -1, -1, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 5
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(8, 4, 6, 9, 1, 7, 2, 5, 0, 3, 11, 10, 13, 12, 15, 14), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 24, 27, 22, 25, 20, 26, 18, 21, 23, 19, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 6
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 10, 13, 3, 8, 12, 9, 20, 4, 6, 1, 11, 5, 2, 25, 22), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(16, 26, 21, 23, 7, 18, 15, 19, 24, 14, 17, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 7
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 5, 14, 11, 15, 17, 18, 7, 19, 21, 6, 8), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(20, 9, 10, 12, 16, 13, 22, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 8
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 4, 3, 2, 6, 5, 8, 7, 13, 10, 15, 16, 9, 18, 11), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(12, 17, 14, 20, 19, 22, 21, 25, 24, 23, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 9
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 7, 3, 8, 5, 10, 2, 4, 11, 6, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 21, 16, 23, 25, 17, 22, 19, 24, 20, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 10
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 3, 2, 1, 7, 6, 5, 4, 9, 8, 12, 16, 10, 14, 13, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 15, 19, 18, 23, 22, 21, 20, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, 0, -1, -1, 0, -1, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 11
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 3, 2, 5, 4, 7, 6, 10, 12, 8, 13, 9, 11, 16, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 19, 15, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 12
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(15, 18, 17, 20, 19, 22, 21, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsUInt32(), s0.AsUInt32()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsUInt32(), s1.AsUInt32()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Store results
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void SortSimd27_512_float(Span<float> span)
+    {
+        ref int first = ref Unsafe.As<float, int>(ref MemoryMarshal.GetReference(span));
+
+        // Load: vec0 = elements [0..15], vec1 = elements [16..26] padded with int.MaxValue
+        var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+        var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+        var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+        var lastThree = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)));
+        var q2 = Sse2.ShiftRightLogical128BitLane(lastThree, 4);
+        var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+
+            // Step 0
+            var s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 26, 25, 24, 23, 22, 21, 20, 9, 8, 11, 10, 15, 14, 13, 12), vec1);
+            var s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 19, 18, 7, 6, 5, 4, 3, 2, 1, 27, 28, 29, 30, 31), vec1);
+            var min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            var max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            var min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            var max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 1
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(1, 0, 3, 2, 5, 4, 7, 6, 10, 11, 8, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 19, 16, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, 0, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 2
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(2, 3, 0, 1, 6, 7, 4, 5, 19, 12, 14, 16, 9, 17, 10, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 13, 15, 8, 22, 23, 20, 21, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, -1, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 3
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(4, 5, 20, 21, 0, 1, 24, 25, 13, 11, 17, 9, 15, 8, 19, 12), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 10, 16, 14, 2, 3, 26, 23, 6, 7, 22, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 4
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 2, 1, 24, 6, 22, 4, 20, 9, 8, 12, 13, 10, 11, 16, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 15, 19, 18, 7, 23, 5, 21, 3, 26, 25, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, -1, 0, -1, -1, -1, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 5
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(8, 4, 6, 9, 1, 7, 2, 5, 0, 3, 11, 10, 13, 12, 15, 14), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 24, 19, 22, 25, 20, 26, 18, 21, 23, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, 0, 0, 0, -1, 0, -1, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 6
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 10, 13, 3, 8, 12, 9, 20, 4, 6, 1, 11, 5, 2, 25, 22), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(16, 26, 21, 23, 7, 18, 15, 19, 24, 14, 17, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 7
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 5, 14, 11, 15, 17, 18, 7, 19, 21, 6, 8), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(20, 9, 10, 12, 16, 13, 22, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 8
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 4, 3, 2, 6, 5, 8, 7, 13, 10, 15, 16, 9, 18, 11), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(12, 17, 14, 20, 19, 22, 21, 25, 24, 23, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 9
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 7, 3, 8, 5, 10, 2, 4, 11, 6, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 21, 16, 23, 25, 17, 22, 19, 24, 20, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 10
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 3, 2, 1, 7, 6, 5, 4, 9, 8, 12, 16, 10, 14, 13, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 15, 19, 18, 23, 22, 21, 20, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, 0, -1, -1, 0, -1, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 11
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 3, 2, 5, 4, 7, 6, 10, 12, 8, 13, 9, 11, 16, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 19, 15, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 12
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(15, 18, 17, 20, 19, 22, 21, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Store results
+        var upper = vec1.GetUpper();
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
+            Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void SortSimd28_512_float(Span<float> span)
+    {
+        ref int first = ref Unsafe.As<float, int>(ref MemoryMarshal.GetReference(span));
+
+        // Load: vec0 = elements [0..15], vec1 = elements [16..27] padded with int.MaxValue
+        var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+        var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+        var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+        var q2 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)));
+        var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+
+            // Step 0
+            var s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(27, 26, 25, 24, 23, 22, 21, 20, 9, 8, 11, 10, 15, 14, 13, 12), vec1);
+            var s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 19, 18, 7, 6, 5, 4, 3, 2, 1, 0, 28, 29, 30, 31), vec1);
+            var min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            var max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            var min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            var max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 1
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(1, 0, 3, 2, 5, 4, 7, 6, 10, 11, 8, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 19, 16, 17, 21, 20, 23, 22, 25, 24, 27, 26, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, -1, 0, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 2
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(2, 3, 0, 1, 6, 7, 4, 5, 19, 12, 14, 16, 9, 17, 10, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 13, 15, 8, 22, 23, 20, 21, 26, 27, 24, 25, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, -1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 3
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(4, 5, 20, 21, 0, 1, 24, 25, 13, 11, 17, 9, 15, 8, 19, 12), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 10, 16, 14, 2, 3, 26, 27, 6, 7, 22, 23, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 4
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 2, 1, 24, 6, 22, 4, 20, 9, 8, 12, 13, 10, 11, 16, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 15, 19, 18, 7, 23, 5, 21, 3, 26, 25, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, -1, 0, -1, -1, -1, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 5
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(8, 4, 6, 9, 1, 7, 2, 5, 0, 3, 11, 10, 13, 12, 15, 14), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(17, 16, 24, 27, 22, 25, 20, 26, 18, 21, 23, 19, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, -1, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, 0, 0, 0, 0, -1, 0, -1, -1, -1, -1, 0, 0, 0, 0), max1, min1);
+
+            // Step 6
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 10, 13, 3, 8, 12, 9, 20, 4, 6, 1, 11, 5, 2, 25, 22), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(16, 26, 21, 23, 7, 18, 15, 19, 24, 14, 17, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, -1, -1, -1, 0, -1, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 7
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 5, 14, 11, 15, 17, 18, 7, 19, 21, 6, 8), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(20, 9, 10, 12, 16, 13, 22, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, -1, -1, -1, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 8
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 4, 3, 2, 6, 5, 8, 7, 13, 10, 15, 16, 9, 18, 11), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(12, 17, 14, 20, 19, 22, 21, 25, 24, 23, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 9
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 7, 3, 8, 5, 10, 2, 4, 11, 6, 9, 14, 15, 12, 13), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(18, 21, 16, 23, 25, 17, 22, 19, 24, 20, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1, -1, 0, -1, -1, 0, 0, -1, -1), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(0, 0, -1, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 10
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 3, 2, 1, 7, 6, 5, 4, 9, 8, 12, 16, 10, 14, 13, 17), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(11, 15, 19, 18, 23, 22, 21, 20, 26, 25, 24, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, 0, -1, -1, 0, -1, 0, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, -1, 0, -1, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 11
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 3, 2, 5, 4, 7, 6, 10, 12, 8, 13, 9, 11, 16, 18), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(14, 19, 15, 17, 21, 20, 23, 22, 25, 24, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, -1, 0, -1, 0, -1, 0, 0, -1, 0, -1, -1, 0, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Step 12
+            s0 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(0, 1, 2, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16), vec1);
+            s1 = Avx512F.PermuteVar16x32x2(vec0, Vector512.Create(15, 18, 17, 20, 19, 22, 21, 24, 23, 25, 26, 27, 28, 29, 30, 31), vec1);
+            min0 = Avx512F.Min(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            max0 = Avx512F.Max(vec0.AsSingle(), s0.AsSingle()).AsInt32();
+            min1 = Avx512F.Min(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            max1 = Avx512F.Max(vec1.AsSingle(), s1.AsSingle()).AsInt32();
+            vec0 = Vector512.ConditionalSelect(Vector512.Create(0, 0, 0, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0), max0, min0);
+            vec1 = Vector512.ConditionalSelect(Vector512.Create(-1, 0, -1, 0, -1, 0, -1, 0, -1, 0, 0, 0, 0, 0, 0, 0), max1, min1);
+
+            // Store results
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+        Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static void SortSimd27_long(Span<long> span)
     {

--- a/SortingNetworks/NetworkSort.cs
+++ b/SortingNetworks/NetworkSort.cs
@@ -386,6 +386,15 @@ public static partial class NetworkSort
         int n = span.Length;
         if (n == 27 || n == 28)
         {
+            if (Avx512F.IsSupported)
+            {
+                if (n == 27)
+                    SortSimd27_512_int(span);
+                else
+                    SortSimd28_512_int(span);
+                return;
+            }
+
             if (Avx2.IsSupported)
             {
                 if (n == 27)
@@ -476,6 +485,15 @@ public static partial class NetworkSort
         int n = span.Length;
         if (n == 27 || n == 28)
         {
+            if (Avx512F.IsSupported)
+            {
+                if (n == 27)
+                    SortSimd27_512_uint(span);
+                else
+                    SortSimd28_512_uint(span);
+                return;
+            }
+
             if (Avx2.IsSupported)
             {
                 if (n == 27)
@@ -962,6 +980,15 @@ public static partial class NetworkSort
         int n = span.Length;
         if (n == 27 || n == 28)
         {
+            if (Avx512F.IsSupported)
+            {
+                if (n == 27)
+                    SortSimd27_512_float(span);
+                else
+                    SortSimd28_512_float(span);
+                return;
+            }
+
             if (Avx2.IsSupported)
             {
                 if (n == 27)

--- a/scripts/generate_unrolled.cs
+++ b/scripts/generate_unrolled.cs
@@ -1267,10 +1267,8 @@ void WriteSimdSortMethod32_Avx512(StreamWriter w, int n, List<List<(int A, int B
     if (n == 27)
     {
         w.WriteLine("""
-                var upper = vec1.GetUpper();
                 Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
-                    Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+                    Sse2.ShiftLeftLogical128BitLane(vec1.GetUpper().GetLower(), 4));
                 Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
                 Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
         """);
@@ -1278,8 +1276,7 @@ void WriteSimdSortMethod32_Avx512(StreamWriter w, int n, List<List<(int A, int B
     else
     {
         w.WriteLine("""
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetLower());
                 Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
                 Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
         """);

--- a/scripts/generate_unrolled.cs
+++ b/scripts/generate_unrolled.cs
@@ -322,6 +322,25 @@ string MaxExpr32(string typeName, string v, string s) => typeName switch
     _ => $"Avx2.Max({v}, {s})",
 };
 
+string FmtVec512_Int(int[] values) =>
+    $"Vector512.Create({string.Join(", ", values)})";
+
+string MinExpr32_512(string typeName, string v, string s) => typeName switch
+{
+    "int" => $"Avx512F.Min({v}, {s})",
+    "uint" => $"Avx512F.Min({v}.AsUInt32(), {s}.AsUInt32()).AsInt32()",
+    "float" => $"Avx512F.Min({v}.AsSingle(), {s}.AsSingle()).AsInt32()",
+    _ => throw new ArgumentException($"Unsupported 32-bit type: {typeName}"),
+};
+
+string MaxExpr32_512(string typeName, string v, string s) => typeName switch
+{
+    "int" => $"Avx512F.Max({v}, {s})",
+    "uint" => $"Avx512F.Max({v}.AsUInt32(), {s}.AsUInt32()).AsInt32()",
+    "float" => $"Avx512F.Max({v}.AsSingle(), {s}.AsSingle()).AsInt32()",
+    _ => throw new ArgumentException($"Unsupported 32-bit type: {typeName}"),
+};
+
 string MinExpr64(string typeName, string v, string s) => typeName switch
 {
     "long" => $"Avx512F.Min({v}, {s})",
@@ -1143,6 +1162,131 @@ void WriteSimdSortMethodDouble(StreamWriter w, int n, List<List<(int A, int B)>>
     w.WriteLine("    }");
 }
 
+void WriteSimdSortMethod32_Avx512(StreamWriter w, int n, List<List<(int A, int B)>> steps, string typeName)
+{
+    int totalSlots = 32;
+
+    string refCast = typeName switch
+    {
+        "uint" => "Unsafe.As<uint, int>(ref ",
+        "float" => "Unsafe.As<float, int>(ref ",
+        _ => "",
+    };
+    string refCastEnd = typeName != "int" ? ")" : "";
+
+    w.WriteLine($$"""
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void SortSimd{{n}}_512_{{typeName}}(Span<{{typeName}}> span)
+        {
+            ref int first = ref {{refCast}}MemoryMarshal.GetReference(span){{refCastEnd}};
+
+            // Load: vec0 = elements [0..15], vec1 = elements [16..{{n - 1}}] padded with int.MaxValue
+            var vec0 = Unsafe.ReadUnaligned<Vector512<int>>(ref Unsafe.As<int, byte>(ref first));
+            var q0 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)));
+            var q1 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)));
+    """);
+
+    if (n == 27)
+    {
+        w.WriteLine("""
+                var lastThree = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)));
+                var q2 = Sse2.ShiftRightLogical128BitLane(lastThree, 4);
+                var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+        """);
+    }
+    else
+    {
+        w.WriteLine("""
+                var q2 = Unsafe.ReadUnaligned<Vector128<int>>(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)));
+                var vec1 = Vector512.Create(Vector256.Create(q0, q1), Vector256.Create(q2, Vector128.Create(int.MaxValue)));
+        """);
+    }
+
+    for (int stepIdx = 0; stepIdx < steps.Count; stepIdx++)
+    {
+        var step = steps[stepIdx];
+
+        int[] permA = new int[totalSlots];
+        int[] permB = new int[totalSlots];
+
+        for (int i = 0; i < totalSlots; i++)
+        {
+            permA[i] = i;
+            permB[i] = i;
+        }
+
+        foreach (var (a, b) in step)
+        {
+            permA[a] = b;
+            permA[b] = a;
+            permB[a] = b;
+            permB[b] = a;
+        }
+
+        int[] indicesVec0 = permA.Take(16).ToArray();
+        int[] indicesVec1 = permA.Skip(16).Take(16).ToArray();
+
+        w.WriteLine();
+        w.WriteLine($"            // Step {stepIdx}");
+
+        string varDecl = stepIdx == 0 ? "var " : "";
+        w.WriteLine($"            {varDecl}s0 = Avx512F.PermuteVar16x32x2(vec0, {FmtVec512_Int(indicesVec0)}, vec1);");
+        w.WriteLine($"            {varDecl}s1 = Avx512F.PermuteVar16x32x2(vec0, {FmtVec512_Int(indicesVec1)}, vec1);");
+
+        w.WriteLine($"            {varDecl}min0 = {MinExpr32_512(typeName, "vec0", "s0")};");
+        w.WriteLine($"            {varDecl}max0 = {MaxExpr32_512(typeName, "vec0", "s0")};");
+        w.WriteLine($"            {varDecl}min1 = {MinExpr32_512(typeName, "vec1", "s1")};");
+        w.WriteLine($"            {varDecl}max1 = {MaxExpr32_512(typeName, "vec1", "s1")};");
+
+        int[] blendMask0 = new int[16];
+        int[] blendMask1 = new int[16];
+
+        for (int i = 0; i < 16; i++)
+        {
+            foreach (var (a, b) in step)
+            {
+                if (b == i) { blendMask0[i] = -1; break; }
+            }
+        }
+
+        for (int i = 0; i < 16; i++)
+        {
+            int globalIdx = i + 16;
+            foreach (var (a, b) in step)
+            {
+                if (b == globalIdx) { blendMask1[i] = -1; break; }
+            }
+        }
+
+        w.WriteLine($"            vec0 = Vector512.ConditionalSelect({FmtVec512_Int(blendMask0)}, max0, min0);");
+        w.WriteLine($"            vec1 = Vector512.ConditionalSelect({FmtVec512_Int(blendMask1)}, max1, min1);");
+    }
+
+    w.WriteLine();
+    w.WriteLine("            // Store results");
+    if (n == 27)
+    {
+        w.WriteLine("""
+                var upper = vec1.GetUpper();
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 23)),
+                    Sse2.ShiftLeftLogical128BitLane(upper.GetUpper(), 4));
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), upper.GetLower());
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+        """);
+    }
+    else
+    {
+        w.WriteLine("""
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 24)), vec1.GetUpper().GetUpper());
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 20)), vec1.GetUpper().GetLower());
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref Unsafe.Add(ref first, 16)), vec1.GetLower());
+                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref first), vec0);
+        """);
+    }
+    w.WriteLine("    }");
+}
+
 void WriteSimdFile(StreamWriter w)
 {
     w.Write("""
@@ -1192,6 +1336,16 @@ void WriteSimdFile(StreamWriter w)
             var steps = GetNetworkSteps(n);
             w.WriteLine();
             WriteSimdSortMethod32_Avx2(w, n, steps, typeName);
+        }
+    }
+
+    foreach (string typeName in new[] { "int", "uint", "float" })
+    {
+        foreach (int n in new[] { 27, 28 })
+        {
+            var steps = GetNetworkSteps(n);
+            w.WriteLine();
+            WriteSimdSortMethod32_Avx512(w, n, steps, typeName);
         }
     }
 
@@ -1528,6 +1682,7 @@ void WritePublicApi(StreamWriter w, string t)
     bool hasSimd8 = t == "byte" || t == "sbyte";
     bool hasSimd16 = t == "short" || t == "ushort" || t == "char";
     bool hasSimd32 = t == "int" || t == "uint";
+    bool hasSimd32_512 = t == "int" || t == "uint" || t == "float";
     bool hasArmSimd32 = t == "int" || t == "uint" || t == "float";
     bool hasSimd64 = t == "long" || t == "ulong" || t == "double";
     bool hasAvx2Float = t == "float" || t == "double";
@@ -1540,37 +1695,20 @@ void WritePublicApi(StreamWriter w, string t)
     w.WriteLine("        int n = span.Length;");
     w.WriteLine("        if (n == 27 || n == 28)");
     w.WriteLine("        {");
-    if (hasSimd8 || hasSimd16 || hasSimd32)
+    if (hasSimd32_512)
     {
-        string isaCheck = hasSimd8 || hasSimd32 ? "Avx2.IsSupported" : "Avx512BW.IsSupported";
-        w.WriteLine($"            if ({isaCheck})");
+        w.WriteLine("            if (Avx512F.IsSupported)");
         w.WriteLine("            {");
         w.WriteLine($"                if (n == 27)");
-        w.WriteLine($"                    SortSimd27{suffix}(span);");
+        w.WriteLine($"                    SortSimd27_512{suffix}(span);");
         w.WriteLine("                else");
-        w.WriteLine($"                    SortSimd28{suffix}(span);");
+        w.WriteLine($"                    SortSimd28_512{suffix}(span);");
         w.WriteLine("                return;");
         w.WriteLine("            }");
         w.WriteLine();
-        if (hasSimd8 || hasSimd16 || hasArmSimd32)
+        if (hasSimd32)
         {
-            w.WriteLine("            if (AdvSimd.Arm64.IsSupported)");
-            w.WriteLine("            {");
-            w.WriteLine($"                if (n == 27)");
-            w.WriteLine($"                    SortSimdArm27{suffix}(span);");
-            w.WriteLine("                else");
-            w.WriteLine($"                    SortSimdArm28{suffix}(span);");
-            w.WriteLine("                return;");
-            w.WriteLine("            }");
-            w.WriteLine();
-        }
-    }
-    else if (hasArmSimd32)
-    {
-        // float: AVX2 first, then ARM fallback
-        if (hasAvx2Float)
-        {
-            w.WriteLine($"            if (Avx2.IsSupported)");
+            w.WriteLine("            if (Avx2.IsSupported)");
             w.WriteLine("            {");
             w.WriteLine($"                if (n == 27)");
             w.WriteLine($"                    SortSimd27{suffix}(span);");
@@ -1580,6 +1718,40 @@ void WritePublicApi(StreamWriter w, string t)
             w.WriteLine("            }");
             w.WriteLine();
         }
+        else if (hasAvx2Float)
+        {
+            w.WriteLine("            if (Avx2.IsSupported)");
+            w.WriteLine("            {");
+            w.WriteLine($"                if (n == 27)");
+            w.WriteLine($"                    SortSimd27{suffix}(span);");
+            w.WriteLine("                else");
+            w.WriteLine($"                    SortSimd28{suffix}(span);");
+            w.WriteLine("                return;");
+            w.WriteLine("            }");
+            w.WriteLine();
+        }
+        w.WriteLine("            if (AdvSimd.Arm64.IsSupported)");
+        w.WriteLine("            {");
+        w.WriteLine($"                if (n == 27)");
+        w.WriteLine($"                    SortSimdArm27{suffix}(span);");
+        w.WriteLine("                else");
+        w.WriteLine($"                    SortSimdArm28{suffix}(span);");
+        w.WriteLine("                return;");
+        w.WriteLine("            }");
+        w.WriteLine();
+    }
+    else if (hasSimd8 || hasSimd16)
+    {
+        string isaCheck = hasSimd8 ? "Avx2.IsSupported" : "Avx512BW.IsSupported";
+        w.WriteLine($"            if ({isaCheck})");
+        w.WriteLine("            {");
+        w.WriteLine($"                if (n == 27)");
+        w.WriteLine($"                    SortSimd27{suffix}(span);");
+        w.WriteLine("                else");
+        w.WriteLine($"                    SortSimd28{suffix}(span);");
+        w.WriteLine("                return;");
+        w.WriteLine("            }");
+        w.WriteLine();
         w.WriteLine("            if (AdvSimd.Arm64.IsSupported)");
         w.WriteLine("            {");
         w.WriteLine($"                if (n == 27)");


### PR DESCRIPTION
Closes #28

## Summary

Adds AVX-512F SIMD sorting paths for 32-bit types (`int`, `uint`, `float`) using `Vector512` — fitting 16 elements per vector register, with 2 registers covering 27-28 element sorting networks.

## Implementation

### Generator (`scripts/generate_unrolled.cs`)
- **`WriteSimdSortMethod32`**: New generator function for 32-bit SIMD sort methods
- **`MinExpr32` / `MaxExpr32`**: Type-specific Min/Max expressions:
  - `int` → `Avx512F.Min/Max` (direct)
  - `uint` → `Avx512F.Min/Max` with `.AsUInt32()` casts
  - `float` → `Avx512F.Min/Max` with `.AsSingle()` casts
- **`FmtVec512_Int`**: Formats `Vector512<int>` literals for permutation indices and blend masks

### Architecture
- **2 × Vector512\<int\>**: `vec0` holds elements 0-15, `vec1` holds elements 16-27/26 (padded to 32 slots)
- **Cross-vector shuffle**: Uses `Avx512F.PermuteVar16x32x2` (VPERMI2D instruction) — selects from 32-element concatenation of both vectors in a single instruction
- **Blend**: `Vector512.ConditionalSelect` with `-1`/`0` masks for max/min position selection
- **Load/Store**: Overlapping reads with `Sse2.ShiftRightLogical128BitLane` for partial Vector128 (n=27), with reverse-order stores to handle overlap correctly

### Dispatch (`NetworkSort.cs`)
- Checks `Avx512F.IsSupported` before falling back to scalar unrolled code
- No ARM SIMD path for 32-bit types (out of scope for this issue)

## Testing
All 135 existing tests pass. The tests cover int/uint/float sorting via `VerifySort` and `StressSort` helpers which compare against `Array.Sort`.