### PR TITLE
Add AVX2 SIMD paths for float and double sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ For `int`, `uint`, and `float` (32-bit types), ARM64 AdvSimd SIMD is used when
 available. The 27-28 elements require seven `Vector128` registers — exceeding
 TBL4's 4-register table limit. This is solved with a two-stage TBL/TBX lookup:
 elements 0-15 are in Table A and elements 16-27 are in Table B, with
-`VectorTableLookupExtension` (TBX) chaining the results. On x86, `int` and
-`uint` use AVX2 SIMD (see above), while `float` falls back to the scalar
-unrolled sort.
+`VectorTableLookupExtension` (TBX) chaining the results.
+
+For `float`, AVX2 SIMD is used on x86 with four `Vector256<float>` registers
+(8 elements each). Cross-vector shuffles use `PermuteVar8x32` with
+`BlendVariable` composition, and `Avx.Min`/`Avx.Max` handles comparisons.
+
+For `double`, AVX-512F SIMD is used on x86 when available (four `Vector512`
+registers). On CPUs without AVX-512F, an AVX2 fallback uses seven
+`Vector256<double>` registers (4 elements each) with `Permute4x64` shuffles.
 
 ## Benchmarks
 
@@ -113,6 +119,20 @@ cross-vector shuffles via `PermuteVar8x32`:
 | int | 103 ns | 58 ns | **1.8x** |
 | uint | 106 ns | 55 ns | **1.9x** |
 
+For `float`, AVX2 SIMD uses four `Vector256<float>` registers with
+`PermuteVar8x32` shuffles and `Avx.Min`/`Avx.Max` comparisons:
+
+| Type | ArraySort (27) | NetworkSort (27) | Speedup |
+|---|---|---|---|
+| float | 1,598 ns | 107 ns | **15x** |
+
+For `double`, AVX2 SIMD uses seven `Vector256<double>` registers with
+`Permute4x64` shuffles (on CPUs with AVX-512F, an AVX-512 path is used instead):
+
+| Type | ArraySort (27) | NetworkSort (27) | Speedup |
+|---|---|---|---|
+| double | 1,630 ns | 110 ns | **15x** |
+
 For other types without a SIMD-optimized `Array.Sort` in the BCL, the unrolled
 sorting network dominates:
 
@@ -120,13 +140,11 @@ sorting network dominates:
 |---|---|---|---|
 | short | 1,411 ns | 101 ns | **14x** |
 | ushort | 1,288 ns | 100 ns | **13x** |
-| float | 1,598 ns | 107 ns | **15x** |
-| double | 1,630 ns | 110 ns | **15x** |
 | long | 1,398 ns | 104 ns | **13x** |
 | nint | 1,408 ns | 105 ns | **13x** |
 | nuint | 1,381 ns | 103 ns | **13x** |
 
-> **Note:** On processors with AVX-512, `short`, `ushort`, and `char` use AVX-512 SIMD (packing all 27-28 elements into a single `Vector512<ushort>`) for even greater speedups.
+> **Note:** On processors with AVX-512, `short`, `ushort`, and `char` use AVX-512BW SIMD, and `long` uses AVX-512F SIMD for even greater speedups.
 
 #### Types where Array.Sort is already SIMD-optimized
 

--- a/SortingNetworks/NetworkSort.Simd.cs
+++ b/SortingNetworks/NetworkSort.Simd.cs
@@ -4859,4 +4859,2076 @@ public static partial class NetworkSort
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 64), v1);
         Unsafe.WriteUnaligned(ref first, v0);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void SortSimd27_float(Span<float> span)
+    {
+        ref byte first = ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(span));
+        var v0 = Unsafe.ReadUnaligned<Vector256<float>>(ref first);
+        var v1 = Unsafe.ReadUnaligned<Vector256<float>>(ref Unsafe.Add(ref first, 32));
+        var v2 = Unsafe.ReadUnaligned<Vector256<float>>(ref Unsafe.Add(ref first, 64));
+        var v3 = Vector256.Create(
+            Sse2.ShiftRightLogical128BitLane(
+                Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref first, 92)),
+                4).AsSingle(),
+            Vector128<float>.Zero);
+
+        // Step 0: (1,26), (2,25), (3,24), (4,23), (5,22), (6,21), (7,20), (8,9), (10,11), (12,15), (13,14), (16,17), (18,19)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 7, 6, 5, 4));
+            var from0_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 2, 1, 0, 4, 5, 6, 7));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+            var shuffled1 = Avx2.PermuteVar8x32(v1, Vector256.Create(1, 0, 3, 2, 7, 6, 5, 4));
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 7, 6, 5, 4));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(1, 0, 3, 2, 4, 5, 6, 7));
+            var shuffled2 = Avx.BlendVariable(from2_0, from2_2, Vector256.Create(-1, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+            var from3_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(3, 2, 1, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_0, from3_3, Vector256.Create(0, 0, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, -1, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, -1, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 1: (0,1), (2,3), (4,5), (6,7), (8,10), (9,11), (12,14), (13,15), (16,18), (17,19), (20,21), (22,23), (24,25)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(1, 0, 3, 2, 5, 4, 7, 6));
+            var shuffled1 = Avx2.PermuteVar8x32(v1, Vector256.Create(2, 3, 0, 1, 6, 7, 4, 5));
+            var shuffled2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 3, 0, 1, 5, 4, 7, 6));
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(1, 0, 2, 3, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, -1, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 2: (0,2), (1,3), (4,6), (5,7), (8,19), (9,12), (10,14), (11,16), (13,17), (15,18), (20,22), (21,23), (24,26)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(2, 3, 0, 1, 6, 7, 4, 5));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 4, 6, 3, 1, 5, 2, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(3, 1, 2, 0, 4, 1, 6, 2));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(-1, 0, 0, -1, 0, -1, 0, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(3, 5, 7, 0, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 6, 7, 4, 5));
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(2, 1, 0, 3, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, -1, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 3: (0,4), (1,5), (2,20), (3,21), (6,24), (7,25), (8,13), (9,11), (10,17), (12,15), (14,19), (16,18), (22,26)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(4, 5, 2, 3, 0, 1, 6, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 4, 5, 4, 5, 6, 7));
+            var from0_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 0, 1));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0, 0, -1, -1, 0, 0, 0, 0).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(5, 3, 2, 1, 7, 0, 6, 4));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 1, 3, 4, 5, 3, 7));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, -1, 0, 0, 0, -1, 0).AsSingle());
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 2, 3, 6, 7));
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 2, 2, 6, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 1, 0, 3, 4, 5, 6, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 2, 7));
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(0, -1, 0, -1, 0, 0, 0, 0).AsSingle());
+            var blend2_2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(-1, 0, -1, 0, 0, 0, 0, -1).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_2, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, -1, 0).AsSingle());
+            var from3_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(6, 7, 2, 3, 4, 5, 6, 7));
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 6, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var blend3_1 = Avx.BlendVariable(from3_0, from3_2, Vector256.Create(0, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_3, Vector256.Create(0, 0, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, -1, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, -1, -1, -1, -1, 0, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, -1, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 4: (1,2), (3,24), (4,6), (5,22), (7,20), (8,9), (10,12), (11,13), (14,16), (15,17), (18,19), (21,23), (25,26)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 2, 1, 3, 6, 5, 4, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 6, 6, 4));
+            var from0_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 0, 4, 5, 6, 7));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0, 0, 0, 0, 0, -1, 0, -1).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0, 0, 0, -1, 0, 0, 0, 0).AsSingle());
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(1, 0, 4, 5, 2, 3, 6, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 0, 1));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 7, 5, 5, 7));
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(6, 7, 2, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 3, 2, 4, 7, 6, 5));
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(-1, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(0, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var from3_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(3, 1, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 2, 1, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_0, from3_3, Vector256.Create(0, -1, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, -1, 0, 0, 0, -1, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, -1, 0, 0, -1, -1, 0, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, -1, 0, -1, -1, 0, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 5: (0,8), (1,4), (2,6), (3,9), (5,7), (10,11), (12,13), (14,15), (16,17), (18,24), (20,22), (21,25), (23,26)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 4, 6, 3, 1, 7, 2, 5));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 1, 4, 5, 6, 7));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(-1, 0, 0, -1, 0, 0, 0, 0).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 3, 2, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 3, 2, 5, 4, 7, 6));
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(1, 0, 2, 3, 6, 5, 4, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 0, 3, 4, 1, 6, 2));
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0, 0, -1, 0, 0, -1, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 5, 7, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0, 0, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, -1, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, -1, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, 0, 0, 0, 0, -1, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, -1, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 6: (1,10), (2,13), (4,8), (5,12), (6,9), (7,20), (14,25), (15,22), (17,26), (18,21), (19,23)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 2, 5, 3, 0, 4, 1, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 4));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, -1, -1, 0, -1, -1, -1, 0).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_2, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(4, 6, 1, 3, 5, 2, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 6));
+            var from1_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 1, 7));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, 0, 0, -1, 0, 0, 0, 0).AsSingle());
+            var blend1_2 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_2, from1_3, Vector256.Create(0, 0, 0, 0, 0, 0, -1, 0).AsSingle());
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 7, 5, 6, 7));
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 7, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 5, 7, 4, 2, 6, 3));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 2, 2, 3, 4, 5, 6, 7));
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(0, 0, 0, 0, 0, 0, -1, 0).AsSingle());
+            var blend2_2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(-1, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_2, from2_3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+            var from3_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 6, 2, 3, 4, 5, 6, 7));
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 1, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var blend3_1 = Avx.BlendVariable(from3_1, from3_2, Vector256.Create(0, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_3, Vector256.Create(-1, 0, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, -1, -1, 0, -1, -1, 0, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 7: (3,4), (6,14), (7,11), (8,15), (9,17), (10,18), (12,19), (13,21), (16,20), (23,24)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 4, 3, 5, 6, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 3));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 7, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 0));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 3, 5, 6, 7));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(-1, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, -1, -1, 0, -1, -1, 0, 0).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 4, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(4, 1, 2, 3, 0, 5, 6, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(-1, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0, -1, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, -1, -1, -1, -1, 0, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 8: (2,4), (5,6), (7,8), (9,13), (11,15), (12,16), (14,18), (19,20), (21,22), (23,25)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 4, 3, 2, 6, 5, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 5, 2, 7, 4, 1, 6, 3));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 0, 5, 2, 7));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, -1, -1, -1, 0, -1, 0, -1).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(4, 1, 6, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 4, 3, 6, 5, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 1));
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, -1, 0, -1, -1, -1, -1, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 7, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(-1, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, 0, 0, 0, 0, -1, 0, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, 0, -1, 0, -1, 0, -1, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 9: (2,7), (4,8), (6,10), (9,11), (12,14), (13,15), (16,18), (17,21), (19,23), (20,25)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 7, 3, 4, 5, 6, 2));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 0, 5, 2, 7));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(4, 1, 6, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 3, 2, 1, 6, 7, 4, 5));
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, -1, 0, -1, -1, -1, -1, -1).AsSingle());
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 5, 0, 7, 4, 1, 6, 3));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 1, 5, 6, 7));
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0, 0, 0, 0, -1, 0, 0, 0).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 4, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(-1, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, 0, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, 0, -1, 0, 0, -1, 0, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 10: (1,3), (4,7), (5,6), (8,9), (10,12), (11,16), (13,14), (15,17), (18,19), (20,23), (21,22), (24,26)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 3, 2, 1, 7, 6, 5, 4));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(1, 0, 4, 3, 2, 6, 5, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 0, 4, 5, 6, 1));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, 0, -1, 0, 0, 0, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(3, 7, 2, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 3, 2, 7, 6, 5, 4));
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(2, 1, 0, 3, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, -1, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, -1, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 11: (2,3), (4,5), (6,7), (8,10), (9,12), (11,13), (14,16), (15,18), (17,19), (20,21), (22,23), (24,25)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 3, 2, 5, 4, 7, 6));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(2, 4, 0, 5, 1, 3, 6, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 0, 2));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(6, 1, 7, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 3, 2, 1, 5, 4, 7, 6));
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, -1, 0, -1, -1, -1, -1, -1).AsSingle());
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(1, 0, 2, 3, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, -1, 0, -1, -1, 0, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 12: (3,4), (5,6), (7,8), (9,10), (11,12), (13,14), (15,16), (17,18), (19,20), (21,22), (23,24)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 4, 3, 6, 5, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 2, 1, 4, 3, 6, 5, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, -1, -1, -1, -1, -1, -1, 0).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 2, 1, 4, 3, 6, 5, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, -1, -1, -1, -1, -1, -1, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0, -1, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, 0, -1, 0, -1, 0, -1, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, 0, -1, 0, -1, 0, -1, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        Sse2.ShiftLeftLogical128BitLane(v3.GetLower().AsByte(), 4)
+            .StoreUnsafe(ref Unsafe.Add(ref first, 92));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 64), v2);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 32), v1);
+        Unsafe.WriteUnaligned(ref first, v0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void SortSimd28_float(Span<float> span)
+    {
+        ref byte first = ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(span));
+        var v0 = Unsafe.ReadUnaligned<Vector256<float>>(ref first);
+        var v1 = Unsafe.ReadUnaligned<Vector256<float>>(ref Unsafe.Add(ref first, 32));
+        var v2 = Unsafe.ReadUnaligned<Vector256<float>>(ref Unsafe.Add(ref first, 64));
+        var v3 = Vector256.Create(
+            Unsafe.ReadUnaligned<Vector128<float>>(ref Unsafe.Add(ref first, 96)),
+            Vector128<float>.Zero);
+
+        // Step 0: (0,27), (1,26), (2,25), (3,24), (4,23), (5,22), (6,21), (7,20), (8,9), (10,11), (12,15), (13,14), (16,17), (18,19)
+        {
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 7, 6, 5, 4));
+            var from0_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(3, 2, 1, 0, 4, 5, 6, 7));
+            var shuffled0 = Avx.BlendVariable(from0_2, from0_3, Vector256.Create(-1, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+            var shuffled1 = Avx2.PermuteVar8x32(v1, Vector256.Create(1, 0, 3, 2, 7, 6, 5, 4));
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 7, 6, 5, 4));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(1, 0, 3, 2, 4, 5, 6, 7));
+            var shuffled2 = Avx.BlendVariable(from2_0, from2_2, Vector256.Create(-1, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+            var from3_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(3, 2, 1, 0, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_0, from3_3, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, -1, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 1: (0,1), (2,3), (4,5), (6,7), (8,10), (9,11), (12,14), (13,15), (16,18), (17,19), (20,21), (22,23), (24,25), (26,27)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(1, 0, 3, 2, 5, 4, 7, 6));
+            var shuffled1 = Avx2.PermuteVar8x32(v1, Vector256.Create(2, 3, 0, 1, 6, 7, 4, 5));
+            var shuffled2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 3, 0, 1, 5, 4, 7, 6));
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(1, 0, 3, 2, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, -1, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, -1, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 2: (0,2), (1,3), (4,6), (5,7), (8,19), (9,12), (10,14), (11,16), (13,17), (15,18), (20,22), (21,23), (24,26), (25,27)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(2, 3, 0, 1, 6, 7, 4, 5));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 4, 6, 3, 1, 5, 2, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(3, 1, 2, 0, 4, 1, 6, 2));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(-1, 0, 0, -1, 0, -1, 0, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(3, 5, 7, 0, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 6, 7, 4, 5));
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(2, 3, 0, 1, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, -1, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, 0, -1, -1, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 3: (0,4), (1,5), (2,20), (3,21), (6,24), (7,25), (8,13), (9,11), (10,17), (12,15), (14,19), (16,18), (22,26), (23,27)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(4, 5, 2, 3, 0, 1, 6, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 4, 5, 4, 5, 6, 7));
+            var from0_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 0, 1));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0, 0, -1, -1, 0, 0, 0, 0).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(5, 3, 2, 1, 7, 0, 6, 4));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 1, 3, 4, 5, 3, 7));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, -1, 0, 0, 0, -1, 0).AsSingle());
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 2, 3, 6, 7));
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 2, 2, 6, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 1, 0, 3, 4, 5, 6, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 2, 3));
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(0, -1, 0, -1, 0, 0, 0, 0).AsSingle());
+            var blend2_2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(-1, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_2, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from3_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(6, 7, 2, 3, 4, 5, 6, 7));
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 6, 7, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var blend3_1 = Avx.BlendVariable(from3_0, from3_2, Vector256.Create(0, 0, -1, -1, 0, 0, 0, 0).AsSingle());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_3, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, -1, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, -1, -1, -1, -1, 0, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 4: (1,2), (3,24), (4,6), (5,22), (7,20), (8,9), (10,12), (11,13), (14,16), (15,17), (18,19), (21,23), (25,26)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 2, 1, 3, 6, 5, 4, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 6, 6, 4));
+            var from0_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 0, 4, 5, 6, 7));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0, 0, 0, 0, 0, -1, 0, -1).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0, 0, 0, -1, 0, 0, 0, 0).AsSingle());
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(1, 0, 4, 5, 2, 3, 6, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 0, 1));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 7, 5, 5, 7));
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(6, 7, 2, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 3, 2, 4, 7, 6, 5));
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(-1, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(0, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var from3_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(3, 1, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 2, 1, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_0, from3_3, Vector256.Create(0, -1, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, -1, 0, 0, 0, -1, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, -1, 0, 0, -1, -1, 0, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, -1, 0, -1, -1, 0, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 5: (0,8), (1,4), (2,6), (3,9), (5,7), (10,11), (12,13), (14,15), (16,17), (18,24), (19,27), (20,22), (21,25), (23,26)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 4, 6, 3, 1, 7, 2, 5));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 1, 4, 5, 6, 7));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(-1, 0, 0, -1, 0, 0, 0, 0).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 3, 2, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 3, 2, 5, 4, 7, 6));
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(1, 0, 2, 3, 6, 5, 4, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 0, 3, 4, 1, 6, 2));
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 5, 7, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, -1, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, -1, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, 0, 0, 0, 0, -1, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, -1, -1, -1, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 6: (1,10), (2,13), (4,8), (5,12), (6,9), (7,20), (14,25), (15,22), (17,26), (18,21), (19,23)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 2, 5, 3, 0, 4, 1, 7));
+            var from0_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 4));
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, -1, -1, 0, -1, -1, -1, 0).AsSingle());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_2, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(4, 6, 1, 3, 5, 2, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 6));
+            var from1_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 1, 7));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, 0, 0, -1, 0, 0, 0, 0).AsSingle());
+            var blend1_2 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_2, from1_3, Vector256.Create(0, 0, 0, 0, 0, 0, -1, 0).AsSingle());
+            var from2_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 3, 7, 5, 6, 7));
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 7, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 5, 7, 4, 2, 6, 3));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 2, 2, 3, 4, 5, 6, 7));
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(0, 0, 0, 0, 0, 0, -1, 0).AsSingle());
+            var blend2_2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(-1, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_2, from2_3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+            var from3_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 6, 2, 3, 4, 5, 6, 7));
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 1, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var blend3_1 = Avx.BlendVariable(from3_1, from3_2, Vector256.Create(0, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_3, Vector256.Create(-1, 0, 0, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, -1, -1, 0, -1, -1, 0, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, 0, 0, 0, -1, -1, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 7: (3,4), (6,14), (7,11), (8,15), (9,17), (10,18), (12,19), (13,21), (16,20), (23,24)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 4, 3, 5, 6, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 3));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 7, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 0));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 3, 5, 6, 7));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(-1, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, -1, -1, 0, -1, -1, 0, 0).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 4, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(4, 1, 2, 3, 0, 5, 6, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(-1, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0, -1, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, 0, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, -1, -1, -1, -1, -1, 0, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 8: (2,4), (5,6), (7,8), (9,13), (11,15), (12,16), (14,18), (19,20), (21,22), (23,25)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 4, 3, 2, 6, 5, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 5, 2, 7, 4, 1, 6, 3));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 0, 5, 2, 7));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, -1, -1, -1, 0, -1, 0, -1).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(4, 1, 6, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 4, 3, 6, 5, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 1));
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, -1, 0, -1, -1, -1, -1, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 7, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(-1, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, 0, 0, 0, 0, -1, 0, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, 0, -1, 0, -1, 0, -1, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 9: (2,7), (4,8), (6,10), (9,11), (12,14), (13,15), (16,18), (17,21), (19,23), (20,25)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 7, 3, 4, 5, 6, 2));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 0, 5, 2, 7));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(4, 1, 6, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 3, 2, 1, 6, 7, 4, 5));
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, -1, 0, -1, -1, -1, -1, -1).AsSingle());
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(2, 5, 0, 7, 4, 1, 6, 3));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 1, 5, 6, 7));
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0, 0, 0, 0, -1, 0, 0, 0).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 4, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(-1, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, 0, -1, -1, 0, 0, -1, -1).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0, 0, -1, 0, 0, -1, 0, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 10: (1,3), (4,7), (5,6), (8,9), (10,12), (11,16), (13,14), (15,17), (18,19), (20,23), (21,22), (24,26)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 3, 2, 1, 7, 6, 5, 4));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(1, 0, 4, 3, 2, 6, 5, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 0, 4, 5, 6, 1));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, 0, -1, 0, 0, 0, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(3, 7, 2, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 3, 2, 7, 6, 5, 4));
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, 0, -1, -1, -1, -1, -1, -1).AsSingle());
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(2, 1, 0, 3, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, -1, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, -1, 0, -1, 0, 0, -1, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, 0, -1, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 11: (2,3), (4,5), (6,7), (8,10), (9,12), (11,13), (14,16), (15,18), (17,19), (20,21), (22,23), (24,25)
+        {
+            var shuffled0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 3, 2, 5, 4, 7, 6));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(2, 4, 0, 5, 1, 3, 6, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 0, 2));
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, -1, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(6, 1, 7, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 3, 2, 1, 5, 4, 7, 6));
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, -1, 0, -1, -1, -1, -1, -1).AsSingle());
+            var shuffled3 = Avx2.PermuteVar8x32(v3, Vector256.Create(1, 0, 2, 3, 4, 5, 6, 7));
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, -1, 0, -1, 0, -1).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0, 0, -1, 0, -1, -1, 0, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, 0, -1, -1, 0, -1, 0, -1).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0, -1, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        // Step 12: (3,4), (5,6), (7,8), (9,10), (11,12), (13,14), (15,16), (17,18), (19,20), (21,22), (23,24)
+        {
+            var from0_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(0, 1, 2, 4, 3, 6, 5, 7));
+            var from0_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from1_0 = Avx2.PermuteVar8x32(v0, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from1_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(0, 2, 1, 4, 3, 6, 5, 7));
+            var from1_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0, -1, -1, -1, -1, -1, -1, 0).AsSingle());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from2_1 = Avx2.PermuteVar8x32(v1, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from2_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(0, 2, 1, 4, 3, 6, 5, 7));
+            var from2_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 0));
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0, -1, -1, -1, -1, -1, -1, 0).AsSingle());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1).AsSingle());
+            var from3_2 = Avx2.PermuteVar8x32(v2, Vector256.Create(7, 1, 2, 3, 4, 5, 6, 7));
+            var from3_3 = Avx2.PermuteVar8x32(v3, Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7));
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0, -1, -1, -1, -1, -1, -1, -1).AsSingle());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0, 0, 0, 0, -1, 0, -1, 0).AsSingle());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1, 0, -1, 0, -1, 0, -1, 0).AsSingle());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1, 0, -1, 0, -1, 0, -1, 0).AsSingle());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1, 0, 0, 0, 0, 0, 0, 0).AsSingle());
+        }
+
+        v3.GetLower().AsByte().StoreUnsafe(ref Unsafe.Add(ref first, 96));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 64), v2);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 32), v1);
+        Unsafe.WriteUnaligned(ref first, v0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void SortSimdAvx2_27_double(Span<double> span)
+    {
+        ref byte first = ref Unsafe.As<double, byte>(ref MemoryMarshal.GetReference(span));
+        var v0 = Unsafe.ReadUnaligned<Vector256<double>>(ref first);
+        var v1 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 32));
+        var v2 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 64));
+        var v3 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 96));
+        var v4 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 128));
+        var v5 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 160));
+        var v6 = Avx2.Permute4x64(
+            Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 184)),
+            0x39);
+
+        // Step 0: (1,26), (2,25), (3,24), (4,23), (5,22), (6,21), (7,20), (8,9), (10,11), (12,15), (13,14), (16,17), (18,19)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_6 = Avx2.Permute4x64(v6, 0x18);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var from1_5 = Avx2.Permute4x64(v5, 0x1B);
+            var shuffled1 = from1_5;
+            var shuffled2 = Avx2.Permute4x64(v2, 0xB1);
+            var shuffled3 = Avx2.Permute4x64(v3, 0x1B);
+            var shuffled4 = Avx2.Permute4x64(v4, 0xB1);
+            var from5_1 = Avx2.Permute4x64(v1, 0x1B);
+            var shuffled5 = from5_1;
+            var from6_0 = Avx2.Permute4x64(v0, 0xDB);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_0, from6_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, -1L, -1L, 0L).AsDouble());
+        }
+
+        // Step 1: (0,1), (2,3), (4,5), (6,7), (8,10), (9,11), (12,14), (13,15), (16,18), (17,19), (20,21), (22,23), (24,25)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0xB1);
+            var shuffled1 = Avx2.Permute4x64(v1, 0xB1);
+            var shuffled2 = Avx2.Permute4x64(v2, 0x4E);
+            var shuffled3 = Avx2.Permute4x64(v3, 0x4E);
+            var shuffled4 = Avx2.Permute4x64(v4, 0x4E);
+            var shuffled5 = Avx2.Permute4x64(v5, 0xB1);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xE1);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 2: (0,2), (1,3), (4,6), (5,7), (8,19), (9,12), (10,14), (11,16), (13,17), (15,18), (20,22), (21,23), (24,26)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0x4E);
+            var shuffled1 = Avx2.Permute4x64(v1, 0x4E);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE0);
+            var from2_4 = Avx2.Permute4x64(v4, 0x27);
+            var shuffled2 = Avx.BlendVariable(from2_3, from2_4, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE5);
+            var from3_4 = Avx2.Permute4x64(v4, 0xA4);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0x27);
+            var from4_3 = Avx2.Permute4x64(v3, 0xF4);
+            var shuffled4 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx2.Permute4x64(v5, 0x4E);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xC6);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+        }
+
+        // Step 3: (0,4), (1,5), (2,20), (3,21), (6,24), (7,25), (8,13), (9,11), (10,17), (12,15), (14,19), (16,18), (22,26)
+        {
+            var from0_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from0_5 = Avx2.Permute4x64(v5, 0x44);
+            var shuffled0 = Avx.BlendVariable(from0_1, from0_5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from1_6 = Avx2.Permute4x64(v6, 0x44);
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_6, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from2_2 = Avx2.Permute4x64(v2, 0x6C);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE5);
+            var from2_4 = Avx2.Permute4x64(v4, 0xD4);
+            var blend2_1 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE0);
+            var from3_3 = Avx2.Permute4x64(v3, 0x27);
+            var from3_4 = Avx2.Permute4x64(v4, 0xF4);
+            var blend3_1 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0xE8);
+            var from4_3 = Avx2.Permute4x64(v3, 0xA4);
+            var from4_4 = Avx2.Permute4x64(v4, 0xC6);
+            var blend4_1 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var from5_0 = Avx2.Permute4x64(v0, 0xEE);
+            var from5_5 = Avx2.Permute4x64(v5, 0xE4);
+            var from5_6 = Avx2.Permute4x64(v6, 0xE4);
+            var blend5_1 = Avx.BlendVariable(from5_0, from5_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from6_1 = Avx2.Permute4x64(v1, 0xEE);
+            var from6_5 = Avx2.Permute4x64(v5, 0xE4);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var blend6_1 = Avx.BlendVariable(from6_1, from6_5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled6 = Avx.BlendVariable(blend6_1, from6_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, -1L, -1L, 0L).AsDouble());
+        }
+
+        // Step 4: (1,2), (3,24), (4,6), (5,22), (7,20), (8,9), (10,12), (11,13), (14,16), (15,17), (18,19), (21,23), (25,26)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xD8);
+            var from0_6 = Avx2.Permute4x64(v6, 0x24);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from1_1 = Avx2.Permute4x64(v1, 0xC6);
+            var from1_5 = Avx2.Permute4x64(v5, 0x28);
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from2_2 = Avx2.Permute4x64(v2, 0xE1);
+            var from2_3 = Avx2.Permute4x64(v3, 0x44);
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xEE);
+            var from3_4 = Avx2.Permute4x64(v4, 0x44);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xEE);
+            var from4_4 = Avx2.Permute4x64(v4, 0xB4);
+            var shuffled4 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from5_1 = Avx2.Permute4x64(v1, 0xD7);
+            var from5_5 = Avx2.Permute4x64(v5, 0x6C);
+            var shuffled5 = Avx.BlendVariable(from5_1, from5_5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from6_0 = Avx2.Permute4x64(v0, 0xE7);
+            var from6_6 = Avx2.Permute4x64(v6, 0xD8);
+            var shuffled6 = Avx.BlendVariable(from6_0, from6_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, -1L, 0L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+        }
+
+        // Step 5: (0,8), (1,4), (2,6), (3,9), (5,7), (10,11), (12,13), (14,15), (16,17), (18,24), (20,22), (21,25), (23,26)
+        {
+            var from0_1 = Avx2.Permute4x64(v1, 0xE0);
+            var from0_2 = Avx2.Permute4x64(v2, 0x64);
+            var shuffled0 = Avx.BlendVariable(from0_1, from0_2, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE5);
+            var from1_1 = Avx2.Permute4x64(v1, 0x6C);
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from2_0 = Avx2.Permute4x64(v0, 0xEC);
+            var from2_2 = Avx2.Permute4x64(v2, 0xB4);
+            var shuffled2 = Avx.BlendVariable(from2_0, from2_2, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var shuffled3 = Avx2.Permute4x64(v3, 0xB1);
+            var from4_4 = Avx2.Permute4x64(v4, 0xE1);
+            var from4_6 = Avx2.Permute4x64(v6, 0xC4);
+            var shuffled4 = Avx.BlendVariable(from4_4, from4_6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from5_5 = Avx2.Permute4x64(v5, 0xC6);
+            var from5_6 = Avx2.Permute4x64(v6, 0xA4);
+            var shuffled5 = Avx.BlendVariable(from5_5, from5_6, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from6_4 = Avx2.Permute4x64(v4, 0xE6);
+            var from6_5 = Avx2.Permute4x64(v5, 0xF4);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var blend6_1 = Avx.BlendVariable(from6_4, from6_5, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled6 = Avx.BlendVariable(blend6_1, from6_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, -1L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, -1L, -1L, 0L).AsDouble());
+        }
+
+        // Step 6: (1,10), (2,13), (4,8), (5,12), (6,9), (7,20), (14,25), (15,22), (17,26), (18,21), (19,23)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_2 = Avx2.Permute4x64(v2, 0xE8);
+            var from0_3 = Avx2.Permute4x64(v3, 0xD4);
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from1_2 = Avx2.Permute4x64(v2, 0xD4);
+            var from1_3 = Avx2.Permute4x64(v3, 0xE0);
+            var from1_5 = Avx2.Permute4x64(v5, 0x24);
+            var blend1_1 = Avx.BlendVariable(from1_2, from1_3, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from2_0 = Avx2.Permute4x64(v0, 0xD4);
+            var from2_1 = Avx2.Permute4x64(v1, 0xE8);
+            var from2_2 = Avx2.Permute4x64(v2, 0xE4);
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from3_0 = Avx2.Permute4x64(v0, 0xE8);
+            var from3_1 = Avx2.Permute4x64(v1, 0xE5);
+            var from3_5 = Avx2.Permute4x64(v5, 0xA4);
+            var from3_6 = Avx2.Permute4x64(v6, 0xD4);
+            var blend3_1 = Avx.BlendVariable(from3_0, from3_1, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var blend3_2 = Avx.BlendVariable(blend3_1, from3_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_2, from3_6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from4_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from4_5 = Avx2.Permute4x64(v5, 0xD4);
+            var from4_6 = Avx2.Permute4x64(v6, 0xE8);
+            var blend4_1 = Avx.BlendVariable(from4_4, from4_5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var from5_1 = Avx2.Permute4x64(v1, 0xE7);
+            var from5_3 = Avx2.Permute4x64(v3, 0xF4);
+            var from5_4 = Avx2.Permute4x64(v4, 0xE8);
+            var blend5_1 = Avx.BlendVariable(from5_1, from5_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from6_3 = Avx2.Permute4x64(v3, 0xE8);
+            var from6_4 = Avx2.Permute4x64(v4, 0xD4);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var blend6_1 = Avx.BlendVariable(from6_3, from6_4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled6 = Avx.BlendVariable(blend6_1, from6_6, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, -1L, -1L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+        }
+
+        // Step 7: (3,4), (6,14), (7,11), (8,15), (9,17), (10,18), (12,19), (13,21), (16,20), (23,24)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0x24);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE7);
+            var from1_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from1_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from1_3 = Avx2.Permute4x64(v3, 0xE4);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var blend1_2 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_2, from1_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE7);
+            var from2_4 = Avx2.Permute4x64(v4, 0xE4);
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_3, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_4, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var from3_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from3_2 = Avx2.Permute4x64(v2, 0x24);
+            var from3_4 = Avx2.Permute4x64(v4, 0xE7);
+            var from3_5 = Avx2.Permute4x64(v5, 0xE4);
+            var blend3_1 = Avx.BlendVariable(from3_1, from3_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var blend3_2 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_2, from3_5, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from4_3 = Avx2.Permute4x64(v3, 0x24);
+            var from4_5 = Avx2.Permute4x64(v5, 0xE4);
+            var blend4_1 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_5, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var from5_3 = Avx2.Permute4x64(v3, 0xE4);
+            var from5_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from5_5 = Avx2.Permute4x64(v5, 0xE4);
+            var from5_6 = Avx2.Permute4x64(v6, 0x24);
+            var blend5_1 = Avx.BlendVariable(from5_3, from5_4, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var blend5_2 = Avx.BlendVariable(blend5_1, from5_5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_2, from5_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xE7);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+        }
+
+        // Step 8: (2,4), (5,6), (7,8), (9,13), (11,15), (12,16), (14,18), (19,20), (21,22), (23,25)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0xC4);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE6);
+            var from1_1 = Avx2.Permute4x64(v1, 0xD8);
+            var from1_2 = Avx2.Permute4x64(v2, 0x24);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE7);
+            var from2_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE4);
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from3_4 = Avx2.Permute4x64(v4, 0xE4);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xE4);
+            var from4_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from4_5 = Avx2.Permute4x64(v5, 0x24);
+            var blend4_1 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from5_4 = Avx2.Permute4x64(v4, 0xE7);
+            var from5_5 = Avx2.Permute4x64(v5, 0xD8);
+            var from5_6 = Avx2.Permute4x64(v6, 0x64);
+            var blend5_1 = Avx.BlendVariable(from5_4, from5_5, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xEC);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 9: (2,7), (4,8), (6,10), (9,11), (12,14), (13,15), (16,18), (17,21), (19,23), (20,25)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0xF4);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xA4);
+            var from1_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from1_2 = Avx2.Permute4x64(v2, 0xE4);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from2_2 = Avx2.Permute4x64(v2, 0x6C);
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var shuffled3 = Avx2.Permute4x64(v3, 0x4E);
+            var from4_4 = Avx2.Permute4x64(v4, 0xC6);
+            var from4_5 = Avx2.Permute4x64(v5, 0xE4);
+            var shuffled4 = Avx.BlendVariable(from4_4, from4_5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from5_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from5_5 = Avx2.Permute4x64(v5, 0xE4);
+            var from5_6 = Avx2.Permute4x64(v6, 0xE5);
+            var blend5_1 = Avx.BlendVariable(from5_4, from5_5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xE0);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 10: (1,3), (4,7), (5,6), (8,9), (10,12), (11,16), (13,14), (15,17), (18,19), (20,23), (21,22), (24,26)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0x6C);
+            var shuffled1 = Avx2.Permute4x64(v1, 0x1B);
+            var from2_2 = Avx2.Permute4x64(v2, 0xE1);
+            var from2_3 = Avx2.Permute4x64(v3, 0xC4);
+            var from2_4 = Avx2.Permute4x64(v4, 0x24);
+            var blend2_1 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_4, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE6);
+            var from3_3 = Avx2.Permute4x64(v3, 0xD8);
+            var from3_4 = Avx2.Permute4x64(v4, 0x64);
+            var blend3_1 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0xE7);
+            var from4_3 = Avx2.Permute4x64(v3, 0xEC);
+            var from4_4 = Avx2.Permute4x64(v4, 0xB4);
+            var blend4_1 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var shuffled5 = Avx2.Permute4x64(v5, 0x1B);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xC6);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, -1L, 0L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+        }
+
+        // Step 11: (2,3), (4,5), (6,7), (8,10), (9,12), (11,13), (14,16), (15,18), (17,19), (20,21), (22,23), (24,25)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0xB4);
+            var shuffled1 = Avx2.Permute4x64(v1, 0xB1);
+            var from2_2 = Avx2.Permute4x64(v2, 0xC6);
+            var from2_3 = Avx2.Permute4x64(v3, 0x60);
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xED);
+            var from3_4 = Avx2.Permute4x64(v4, 0x84);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xF6);
+            var from4_4 = Avx2.Permute4x64(v4, 0x6C);
+            var shuffled4 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var shuffled5 = Avx2.Permute4x64(v5, 0xB1);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xE1);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 12: (3,4), (5,6), (7,8), (9,10), (11,12), (13,14), (15,16), (17,18), (19,20), (21,22), (23,24)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0x24);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE7);
+            var from1_1 = Avx2.Permute4x64(v1, 0xD8);
+            var from1_2 = Avx2.Permute4x64(v2, 0x24);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE7);
+            var from2_2 = Avx2.Permute4x64(v2, 0xD8);
+            var from2_3 = Avx2.Permute4x64(v3, 0x24);
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE7);
+            var from3_3 = Avx2.Permute4x64(v3, 0xD8);
+            var from3_4 = Avx2.Permute4x64(v4, 0x24);
+            var blend3_1 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xE7);
+            var from4_4 = Avx2.Permute4x64(v4, 0xD8);
+            var from4_5 = Avx2.Permute4x64(v5, 0x24);
+            var blend4_1 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from5_4 = Avx2.Permute4x64(v4, 0xE7);
+            var from5_5 = Avx2.Permute4x64(v5, 0xD8);
+            var from5_6 = Avx2.Permute4x64(v6, 0x24);
+            var blend5_1 = Avx.BlendVariable(from5_4, from5_5, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xE7);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+        }
+
+        Avx2.Permute4x64(v6, 0x93).AsByte()
+            .StoreUnsafe(ref Unsafe.Add(ref first, 184));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 160), v5);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 128), v4);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 96), v3);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 64), v2);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 32), v1);
+        Unsafe.WriteUnaligned(ref first, v0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static void SortSimdAvx2_28_double(Span<double> span)
+    {
+        ref byte first = ref Unsafe.As<double, byte>(ref MemoryMarshal.GetReference(span));
+        var v0 = Unsafe.ReadUnaligned<Vector256<double>>(ref first);
+        var v1 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 32));
+        var v2 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 64));
+        var v3 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 96));
+        var v4 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 128));
+        var v5 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 160));
+        var v6 = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, 192));
+
+        // Step 0: (0,27), (1,26), (2,25), (3,24), (4,23), (5,22), (6,21), (7,20), (8,9), (10,11), (12,15), (13,14), (16,17), (18,19)
+        {
+            var from0_6 = Avx2.Permute4x64(v6, 0x1B);
+            var shuffled0 = from0_6;
+            var from1_5 = Avx2.Permute4x64(v5, 0x1B);
+            var shuffled1 = from1_5;
+            var shuffled2 = Avx2.Permute4x64(v2, 0xB1);
+            var shuffled3 = Avx2.Permute4x64(v3, 0x1B);
+            var shuffled4 = Avx2.Permute4x64(v4, 0xB1);
+            var from5_1 = Avx2.Permute4x64(v1, 0x1B);
+            var shuffled5 = from5_1;
+            var from6_0 = Avx2.Permute4x64(v0, 0x1B);
+            var shuffled6 = from6_0;
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+        }
+
+        // Step 1: (0,1), (2,3), (4,5), (6,7), (8,10), (9,11), (12,14), (13,15), (16,18), (17,19), (20,21), (22,23), (24,25), (26,27)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0xB1);
+            var shuffled1 = Avx2.Permute4x64(v1, 0xB1);
+            var shuffled2 = Avx2.Permute4x64(v2, 0x4E);
+            var shuffled3 = Avx2.Permute4x64(v3, 0x4E);
+            var shuffled4 = Avx2.Permute4x64(v4, 0x4E);
+            var shuffled5 = Avx2.Permute4x64(v5, 0xB1);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xB1);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+        }
+
+        // Step 2: (0,2), (1,3), (4,6), (5,7), (8,19), (9,12), (10,14), (11,16), (13,17), (15,18), (20,22), (21,23), (24,26), (25,27)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0x4E);
+            var shuffled1 = Avx2.Permute4x64(v1, 0x4E);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE0);
+            var from2_4 = Avx2.Permute4x64(v4, 0x27);
+            var shuffled2 = Avx.BlendVariable(from2_3, from2_4, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE5);
+            var from3_4 = Avx2.Permute4x64(v4, 0xA4);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0x27);
+            var from4_3 = Avx2.Permute4x64(v3, 0xF4);
+            var shuffled4 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx2.Permute4x64(v5, 0x4E);
+            var shuffled6 = Avx2.Permute4x64(v6, 0x4E);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+        }
+
+        // Step 3: (0,4), (1,5), (2,20), (3,21), (6,24), (7,25), (8,13), (9,11), (10,17), (12,15), (14,19), (16,18), (22,26), (23,27)
+        {
+            var from0_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from0_5 = Avx2.Permute4x64(v5, 0x44);
+            var shuffled0 = Avx.BlendVariable(from0_1, from0_5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from1_6 = Avx2.Permute4x64(v6, 0x44);
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_6, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from2_2 = Avx2.Permute4x64(v2, 0x6C);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE5);
+            var from2_4 = Avx2.Permute4x64(v4, 0xD4);
+            var blend2_1 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE0);
+            var from3_3 = Avx2.Permute4x64(v3, 0x27);
+            var from3_4 = Avx2.Permute4x64(v4, 0xF4);
+            var blend3_1 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0xE8);
+            var from4_3 = Avx2.Permute4x64(v3, 0xA4);
+            var from4_4 = Avx2.Permute4x64(v4, 0xC6);
+            var blend4_1 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var from5_0 = Avx2.Permute4x64(v0, 0xEE);
+            var from5_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled5 = Avx.BlendVariable(from5_0, from5_6, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from6_1 = Avx2.Permute4x64(v1, 0xEE);
+            var from6_5 = Avx2.Permute4x64(v5, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_1, from6_5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+        }
+
+        // Step 4: (1,2), (3,24), (4,6), (5,22), (7,20), (8,9), (10,12), (11,13), (14,16), (15,17), (18,19), (21,23), (25,26)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xD8);
+            var from0_6 = Avx2.Permute4x64(v6, 0x24);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from1_1 = Avx2.Permute4x64(v1, 0xC6);
+            var from1_5 = Avx2.Permute4x64(v5, 0x28);
+            var shuffled1 = Avx.BlendVariable(from1_1, from1_5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from2_2 = Avx2.Permute4x64(v2, 0xE1);
+            var from2_3 = Avx2.Permute4x64(v3, 0x44);
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xEE);
+            var from3_4 = Avx2.Permute4x64(v4, 0x44);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xEE);
+            var from4_4 = Avx2.Permute4x64(v4, 0xB4);
+            var shuffled4 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from5_1 = Avx2.Permute4x64(v1, 0xD7);
+            var from5_5 = Avx2.Permute4x64(v5, 0x6C);
+            var shuffled5 = Avx.BlendVariable(from5_1, from5_5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from6_0 = Avx2.Permute4x64(v0, 0xE7);
+            var from6_6 = Avx2.Permute4x64(v6, 0xD8);
+            var shuffled6 = Avx.BlendVariable(from6_0, from6_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, -1L, 0L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+        }
+
+        // Step 5: (0,8), (1,4), (2,6), (3,9), (5,7), (10,11), (12,13), (14,15), (16,17), (18,24), (19,27), (20,22), (21,25), (23,26)
+        {
+            var from0_1 = Avx2.Permute4x64(v1, 0xE0);
+            var from0_2 = Avx2.Permute4x64(v2, 0x64);
+            var shuffled0 = Avx.BlendVariable(from0_1, from0_2, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE5);
+            var from1_1 = Avx2.Permute4x64(v1, 0x6C);
+            var shuffled1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from2_0 = Avx2.Permute4x64(v0, 0xEC);
+            var from2_2 = Avx2.Permute4x64(v2, 0xB4);
+            var shuffled2 = Avx.BlendVariable(from2_0, from2_2, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var shuffled3 = Avx2.Permute4x64(v3, 0xB1);
+            var from4_4 = Avx2.Permute4x64(v4, 0xE1);
+            var from4_6 = Avx2.Permute4x64(v6, 0xC4);
+            var shuffled4 = Avx.BlendVariable(from4_4, from4_6, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from5_5 = Avx2.Permute4x64(v5, 0xC6);
+            var from5_6 = Avx2.Permute4x64(v6, 0xA4);
+            var shuffled5 = Avx.BlendVariable(from5_5, from5_6, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from6_4 = Avx2.Permute4x64(v4, 0xE6);
+            var from6_5 = Avx2.Permute4x64(v5, 0xF4);
+            var shuffled6 = Avx.BlendVariable(from6_4, from6_5, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, -1L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+        }
+
+        // Step 6: (1,10), (2,13), (4,8), (5,12), (6,9), (7,20), (14,25), (15,22), (17,26), (18,21), (19,23)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_2 = Avx2.Permute4x64(v2, 0xE8);
+            var from0_3 = Avx2.Permute4x64(v3, 0xD4);
+            var blend0_1 = Avx.BlendVariable(from0_0, from0_2, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled0 = Avx.BlendVariable(blend0_1, from0_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from1_2 = Avx2.Permute4x64(v2, 0xD4);
+            var from1_3 = Avx2.Permute4x64(v3, 0xE0);
+            var from1_5 = Avx2.Permute4x64(v5, 0x24);
+            var blend1_1 = Avx.BlendVariable(from1_2, from1_3, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from2_0 = Avx2.Permute4x64(v0, 0xD4);
+            var from2_1 = Avx2.Permute4x64(v1, 0xE8);
+            var from2_2 = Avx2.Permute4x64(v2, 0xE4);
+            var blend2_1 = Avx.BlendVariable(from2_0, from2_1, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from3_0 = Avx2.Permute4x64(v0, 0xE8);
+            var from3_1 = Avx2.Permute4x64(v1, 0xE5);
+            var from3_5 = Avx2.Permute4x64(v5, 0xA4);
+            var from3_6 = Avx2.Permute4x64(v6, 0xD4);
+            var blend3_1 = Avx.BlendVariable(from3_0, from3_1, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var blend3_2 = Avx.BlendVariable(blend3_1, from3_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_2, from3_6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from4_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from4_5 = Avx2.Permute4x64(v5, 0xD4);
+            var from4_6 = Avx2.Permute4x64(v6, 0xE8);
+            var blend4_1 = Avx.BlendVariable(from4_4, from4_5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var from5_1 = Avx2.Permute4x64(v1, 0xE7);
+            var from5_3 = Avx2.Permute4x64(v3, 0xF4);
+            var from5_4 = Avx2.Permute4x64(v4, 0xE8);
+            var blend5_1 = Avx.BlendVariable(from5_1, from5_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from6_3 = Avx2.Permute4x64(v3, 0xE8);
+            var from6_4 = Avx2.Permute4x64(v4, 0xD4);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var blend6_1 = Avx.BlendVariable(from6_3, from6_4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled6 = Avx.BlendVariable(blend6_1, from6_6, Vector256.Create(-1L, 0L, 0L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, -1L, -1L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+        }
+
+        // Step 7: (3,4), (6,14), (7,11), (8,15), (9,17), (10,18), (12,19), (13,21), (16,20), (23,24)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0x24);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE7);
+            var from1_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from1_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from1_3 = Avx2.Permute4x64(v3, 0xE4);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var blend1_2 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_2, from1_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE7);
+            var from2_4 = Avx2.Permute4x64(v4, 0xE4);
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_3, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_4, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var from3_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from3_2 = Avx2.Permute4x64(v2, 0x24);
+            var from3_4 = Avx2.Permute4x64(v4, 0xE7);
+            var from3_5 = Avx2.Permute4x64(v5, 0xE4);
+            var blend3_1 = Avx.BlendVariable(from3_1, from3_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var blend3_2 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_2, from3_5, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from4_3 = Avx2.Permute4x64(v3, 0x24);
+            var from4_5 = Avx2.Permute4x64(v5, 0xE4);
+            var blend4_1 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_5, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var from5_3 = Avx2.Permute4x64(v3, 0xE4);
+            var from5_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from5_5 = Avx2.Permute4x64(v5, 0xE4);
+            var from5_6 = Avx2.Permute4x64(v6, 0x24);
+            var blend5_1 = Avx.BlendVariable(from5_3, from5_4, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var blend5_2 = Avx.BlendVariable(blend5_1, from5_5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_2, from5_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xE7);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+        }
+
+        // Step 8: (2,4), (5,6), (7,8), (9,13), (11,15), (12,16), (14,18), (19,20), (21,22), (23,25)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0xC4);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE6);
+            var from1_1 = Avx2.Permute4x64(v1, 0xD8);
+            var from1_2 = Avx2.Permute4x64(v2, 0x24);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE7);
+            var from2_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from2_3 = Avx2.Permute4x64(v3, 0xE4);
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE4);
+            var from3_4 = Avx2.Permute4x64(v4, 0xE4);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xE4);
+            var from4_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from4_5 = Avx2.Permute4x64(v5, 0x24);
+            var blend4_1 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from5_4 = Avx2.Permute4x64(v4, 0xE7);
+            var from5_5 = Avx2.Permute4x64(v5, 0xD8);
+            var from5_6 = Avx2.Permute4x64(v6, 0x64);
+            var blend5_1 = Avx.BlendVariable(from5_4, from5_5, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xEC);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 9: (2,7), (4,8), (6,10), (9,11), (12,14), (13,15), (16,18), (17,21), (19,23), (20,25)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0xF4);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xA4);
+            var from1_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from1_2 = Avx2.Permute4x64(v2, 0xE4);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE4);
+            var from2_2 = Avx2.Permute4x64(v2, 0x6C);
+            var shuffled2 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var shuffled3 = Avx2.Permute4x64(v3, 0x4E);
+            var from4_4 = Avx2.Permute4x64(v4, 0xC6);
+            var from4_5 = Avx2.Permute4x64(v5, 0xE4);
+            var shuffled4 = Avx.BlendVariable(from4_4, from4_5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from5_4 = Avx2.Permute4x64(v4, 0xE4);
+            var from5_5 = Avx2.Permute4x64(v5, 0xE4);
+            var from5_6 = Avx2.Permute4x64(v6, 0xE5);
+            var blend5_1 = Avx.BlendVariable(from5_4, from5_5, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xE0);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 10: (1,3), (4,7), (5,6), (8,9), (10,12), (11,16), (13,14), (15,17), (18,19), (20,23), (21,22), (24,26)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0x6C);
+            var shuffled1 = Avx2.Permute4x64(v1, 0x1B);
+            var from2_2 = Avx2.Permute4x64(v2, 0xE1);
+            var from2_3 = Avx2.Permute4x64(v3, 0xC4);
+            var from2_4 = Avx2.Permute4x64(v4, 0x24);
+            var blend2_1 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_4, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE6);
+            var from3_3 = Avx2.Permute4x64(v3, 0xD8);
+            var from3_4 = Avx2.Permute4x64(v4, 0x64);
+            var blend3_1 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from4_2 = Avx2.Permute4x64(v2, 0xE7);
+            var from4_3 = Avx2.Permute4x64(v3, 0xEC);
+            var from4_4 = Avx2.Permute4x64(v4, 0xB4);
+            var blend4_1 = Avx.BlendVariable(from4_2, from4_3, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var shuffled5 = Avx2.Permute4x64(v5, 0x1B);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xC6);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, -1L, 0L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+        }
+
+        // Step 11: (2,3), (4,5), (6,7), (8,10), (9,12), (11,13), (14,16), (15,18), (17,19), (20,21), (22,23), (24,25)
+        {
+            var shuffled0 = Avx2.Permute4x64(v0, 0xB4);
+            var shuffled1 = Avx2.Permute4x64(v1, 0xB1);
+            var from2_2 = Avx2.Permute4x64(v2, 0xC6);
+            var from2_3 = Avx2.Permute4x64(v3, 0x60);
+            var shuffled2 = Avx.BlendVariable(from2_2, from2_3, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xED);
+            var from3_4 = Avx2.Permute4x64(v4, 0x84);
+            var shuffled3 = Avx.BlendVariable(from3_2, from3_4, Vector256.Create(0L, 0L, -1L, -1L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xF6);
+            var from4_4 = Avx2.Permute4x64(v4, 0x6C);
+            var shuffled4 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var shuffled5 = Avx2.Permute4x64(v5, 0xB1);
+            var shuffled6 = Avx2.Permute4x64(v6, 0xE1);
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(0L, 0L, -1L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, -1L, 0L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, 0L, -1L, -1L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(0L, -1L, 0L, -1L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(0L, -1L, 0L, 0L).AsDouble());
+        }
+
+        // Step 12: (3,4), (5,6), (7,8), (9,10), (11,12), (13,14), (15,16), (17,18), (19,20), (21,22), (23,24)
+        {
+            var from0_0 = Avx2.Permute4x64(v0, 0xE4);
+            var from0_1 = Avx2.Permute4x64(v1, 0x24);
+            var shuffled0 = Avx.BlendVariable(from0_0, from0_1, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from1_0 = Avx2.Permute4x64(v0, 0xE7);
+            var from1_1 = Avx2.Permute4x64(v1, 0xD8);
+            var from1_2 = Avx2.Permute4x64(v2, 0x24);
+            var blend1_1 = Avx.BlendVariable(from1_0, from1_1, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled1 = Avx.BlendVariable(blend1_1, from1_2, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from2_1 = Avx2.Permute4x64(v1, 0xE7);
+            var from2_2 = Avx2.Permute4x64(v2, 0xD8);
+            var from2_3 = Avx2.Permute4x64(v3, 0x24);
+            var blend2_1 = Avx.BlendVariable(from2_1, from2_2, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled2 = Avx.BlendVariable(blend2_1, from2_3, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from3_2 = Avx2.Permute4x64(v2, 0xE7);
+            var from3_3 = Avx2.Permute4x64(v3, 0xD8);
+            var from3_4 = Avx2.Permute4x64(v4, 0x24);
+            var blend3_1 = Avx.BlendVariable(from3_2, from3_3, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled3 = Avx.BlendVariable(blend3_1, from3_4, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from4_3 = Avx2.Permute4x64(v3, 0xE7);
+            var from4_4 = Avx2.Permute4x64(v4, 0xD8);
+            var from4_5 = Avx2.Permute4x64(v5, 0x24);
+            var blend4_1 = Avx.BlendVariable(from4_3, from4_4, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled4 = Avx.BlendVariable(blend4_1, from4_5, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from5_4 = Avx2.Permute4x64(v4, 0xE7);
+            var from5_5 = Avx2.Permute4x64(v5, 0xD8);
+            var from5_6 = Avx2.Permute4x64(v6, 0x24);
+            var blend5_1 = Avx.BlendVariable(from5_4, from5_5, Vector256.Create(0L, -1L, -1L, 0L).AsDouble());
+            var shuffled5 = Avx.BlendVariable(blend5_1, from5_6, Vector256.Create(0L, 0L, 0L, -1L).AsDouble());
+            var from6_5 = Avx2.Permute4x64(v5, 0xE7);
+            var from6_6 = Avx2.Permute4x64(v6, 0xE4);
+            var shuffled6 = Avx.BlendVariable(from6_5, from6_6, Vector256.Create(0L, -1L, -1L, -1L).AsDouble());
+            var mins0 = Avx.Min(v0, shuffled0);
+            var maxs0 = Avx.Max(v0, shuffled0);
+            v0 = Avx.BlendVariable(mins0, maxs0, Vector256.Create(0L, 0L, 0L, 0L).AsDouble());
+            var mins1 = Avx.Min(v1, shuffled1);
+            var maxs1 = Avx.Max(v1, shuffled1);
+            v1 = Avx.BlendVariable(mins1, maxs1, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins2 = Avx.Min(v2, shuffled2);
+            var maxs2 = Avx.Max(v2, shuffled2);
+            v2 = Avx.BlendVariable(mins2, maxs2, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins3 = Avx.Min(v3, shuffled3);
+            var maxs3 = Avx.Max(v3, shuffled3);
+            v3 = Avx.BlendVariable(mins3, maxs3, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins4 = Avx.Min(v4, shuffled4);
+            var maxs4 = Avx.Max(v4, shuffled4);
+            v4 = Avx.BlendVariable(mins4, maxs4, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins5 = Avx.Min(v5, shuffled5);
+            var maxs5 = Avx.Max(v5, shuffled5);
+            v5 = Avx.BlendVariable(mins5, maxs5, Vector256.Create(-1L, 0L, -1L, 0L).AsDouble());
+            var mins6 = Avx.Min(v6, shuffled6);
+            var maxs6 = Avx.Max(v6, shuffled6);
+            v6 = Avx.BlendVariable(mins6, maxs6, Vector256.Create(-1L, 0L, 0L, 0L).AsDouble());
+        }
+
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 192), v6);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 160), v5);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 128), v4);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 96), v3);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 64), v2);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, 32), v1);
+        Unsafe.WriteUnaligned(ref first, v0);
+    }
 }

--- a/SortingNetworks/NetworkSort.cs
+++ b/SortingNetworks/NetworkSort.cs
@@ -962,6 +962,15 @@ public static partial class NetworkSort
         int n = span.Length;
         if (n == 27 || n == 28)
         {
+            if (Avx2.IsSupported)
+            {
+                if (n == 27)
+                    SortSimd27_float(span);
+                else
+                    SortSimd28_float(span);
+                return;
+            }
+
             if (AdvSimd.Arm64.IsSupported)
             {
                 if (n == 27)
@@ -1049,6 +1058,15 @@ public static partial class NetworkSort
                     SortSimd27_double(span);
                 else
                     SortSimd28_double(span);
+                return;
+            }
+
+            if (Avx2.IsSupported)
+            {
+                if (n == 27)
+                    SortSimdAvx2_27_double(span);
+                else
+                    SortSimdAvx2_28_double(span);
                 return;
             }
 

--- a/scripts/generate_unrolled.cs
+++ b/scripts/generate_unrolled.cs
@@ -307,6 +307,9 @@ string MaxExpr16(string typeName, string v, string s) => typeName switch
 string FmtVec256_Int(int[] values) =>
     $"Vector256.Create({string.Join(", ", values)})";
 
+string FmtVec256_Long(long[] values) =>
+    $"Vector256.Create({string.Join(", ", values.Select(v => $"{v}L"))})";
+
 string MinExpr32(string typeName, string v, string s) => typeName switch
 {
     "uint" => $"Avx2.Min({v}.AsUInt32(), {s}.AsUInt32()).AsInt32()",
@@ -806,6 +809,340 @@ void WriteSimdSortMethod64(StreamWriter w, int n, List<List<(int A, int B)>> ste
     w.WriteLine("    }");
 }
 
+void WriteSimdSortMethodFloat(StreamWriter w, int n, List<List<(int A, int B)>> steps)
+{
+    int regSize = 8;
+    int numRegs = (n + regSize - 1) / regSize;
+    int lastRegElems = n - (numRegs - 1) * regSize;
+    int lastRegOffset = (numRegs - 1) * regSize * 4;
+
+    w.WriteLine($"    [MethodImpl(MethodImplOptions.AggressiveOptimization)]");
+    w.WriteLine($"    private static void SortSimd{n}_float(Span<float> span)");
+    w.WriteLine("    {");
+    w.WriteLine("        ref byte first = ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(span));");
+
+    for (int ri = 0; ri < numRegs - 1; ri++)
+    {
+        if (ri == 0)
+            w.WriteLine("        var v0 = Unsafe.ReadUnaligned<Vector256<float>>(ref first);");
+        else
+            w.WriteLine($"        var v{ri} = Unsafe.ReadUnaligned<Vector256<float>>(ref Unsafe.Add(ref first, {ri * 32}));");
+    }
+
+    if (lastRegElems >= regSize)
+    {
+        w.WriteLine($"        var v{numRegs - 1} = Unsafe.ReadUnaligned<Vector256<float>>(ref Unsafe.Add(ref first, {lastRegOffset}));");
+    }
+    else if (lastRegElems == 4)
+    {
+        w.WriteLine($"        var v{numRegs - 1} = Vector256.Create(");
+        w.WriteLine($"            Unsafe.ReadUnaligned<Vector128<float>>(ref Unsafe.Add(ref first, {lastRegOffset})),");
+        w.WriteLine("            Vector128<float>.Zero);");
+    }
+    else
+    {
+        int overlapOffset = (n - 4) * 4;
+        int shiftBytes = (4 - lastRegElems) * 4;
+        w.WriteLine($"        var v{numRegs - 1} = Vector256.Create(");
+        w.WriteLine($"            Sse2.ShiftRightLogical128BitLane(");
+        w.WriteLine($"                Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref first, {overlapOffset})),");
+        w.WriteLine($"                {shiftBytes}).AsSingle(),");
+        w.WriteLine("            Vector128<float>.Zero);");
+    }
+
+    int totalSlots = numRegs * regSize;
+
+    for (int si = 0; si < steps.Count; si++)
+    {
+        var step = steps[si];
+        int[] perm = Enumerable.Range(0, totalSlots).ToArray();
+        foreach (var (a, b) in step) { perm[a] = b; perm[b] = a; }
+        bool[] isMax = new bool[totalSlots];
+        foreach (var (a, b) in step) isMax[Math.Max(a, b)] = true;
+
+        string pairStr = string.Join(", ", step.Select(p => $"({p.A},{p.B})"));
+        w.WriteLine();
+        w.WriteLine($"        // Step {si}: {pairStr}");
+        w.WriteLine("        {");
+
+        // Identify active registers
+        var activeRegs = new List<int>();
+        for (int tri = 0; tri < numRegs; tri++)
+        {
+            int baseElem = tri * regSize;
+            bool hasWork = false;
+            for (int lane = 0; lane < regSize; lane++)
+                if (perm[baseElem + lane] != baseElem + lane) { hasWork = true; break; }
+            if (hasWork) activeRegs.Add(tri);
+        }
+
+        // Pass 1: compute all shuffled vectors from unmodified registers
+        foreach (int tri in activeRegs)
+        {
+            int baseElem = tri * regSize;
+            var sourceGroups = new Dictionary<int, List<(int destLane, int srcLane)>>();
+            for (int lane = 0; lane < regSize; lane++)
+            {
+                int srcElem = perm[baseElem + lane];
+                int srcReg = srcElem / regSize;
+                int srcLane = srcElem % regSize;
+                if (!sourceGroups.ContainsKey(srcReg))
+                    sourceGroups[srcReg] = [];
+                sourceGroups[srcReg].Add((lane, srcLane));
+            }
+
+            var sortedSources = sourceGroups.Keys.OrderBy(k => k).ToList();
+
+            if (sortedSources.Count == 1 && sortedSources[0] == tri)
+            {
+                int[] permIdx = new int[regSize];
+                for (int lane = 0; lane < regSize; lane++)
+                    permIdx[lane] = perm[baseElem + lane] % regSize;
+                w.WriteLine($"            var shuffled{tri} = Avx2.PermuteVar8x32(v{tri}, {FmtVec256_Int(permIdx)});");
+            }
+            else
+            {
+                foreach (int srcReg in sortedSources)
+                {
+                    int[] permIdx = new int[regSize];
+                    for (int lane = 0; lane < regSize; lane++)
+                        permIdx[lane] = lane;
+                    foreach (var (destLane, srcLane) in sourceGroups[srcReg])
+                        permIdx[destLane] = srcLane;
+                    w.WriteLine($"            var from{tri}_{srcReg} = Avx2.PermuteVar8x32(v{srcReg}, {FmtVec256_Int(permIdx)});");
+                }
+
+                if (sortedSources.Count == 1)
+                {
+                    w.WriteLine($"            var shuffled{tri} = from{tri}_{sortedSources[0]};");
+                }
+                else
+                {
+                    string prev = $"from{tri}_{sortedSources[0]}";
+                    for (int bi = 1; bi < sortedSources.Count; bi++)
+                    {
+                        int srcReg = sortedSources[bi];
+                        int[] blendMask = new int[regSize];
+                        foreach (var (destLane, _) in sourceGroups[srcReg])
+                            blendMask[destLane] = -1;
+                        string next = bi < sortedSources.Count - 1 ? $"blend{tri}_{bi}" : $"shuffled{tri}";
+                        w.WriteLine($"            var {next} = Avx.BlendVariable({prev}, from{tri}_{srcReg}, {FmtVec256_Int(blendMask)}.AsSingle());");
+                        prev = next;
+                    }
+                }
+            }
+        }
+
+        // Pass 2: apply min/max/blend using shuffled vectors
+        foreach (int tri in activeRegs)
+        {
+            int baseElem = tri * regSize;
+            int[] maxMask = new int[regSize];
+            for (int lane = 0; lane < regSize; lane++)
+                if (isMax[baseElem + lane]) maxMask[lane] = -1;
+            w.WriteLine($"            var mins{tri} = Avx.Min(v{tri}, shuffled{tri});");
+            w.WriteLine($"            var maxs{tri} = Avx.Max(v{tri}, shuffled{tri});");
+            w.WriteLine($"            v{tri} = Avx.BlendVariable(mins{tri}, maxs{tri}, {FmtVec256_Int(maxMask)}.AsSingle());");
+        }
+
+        w.WriteLine("        }");
+    }
+
+    w.WriteLine();
+    if (lastRegElems < 4)
+    {
+        int overlapOffset = (n - 4) * 4;
+        int shiftBytes = (4 - lastRegElems) * 4;
+        w.WriteLine($"        Sse2.ShiftLeftLogical128BitLane(v{numRegs - 1}.GetLower().AsByte(), {shiftBytes})");
+        w.WriteLine($"            .StoreUnsafe(ref Unsafe.Add(ref first, {overlapOffset}));");
+    }
+    else if (lastRegElems == 4)
+    {
+        w.WriteLine($"        v{numRegs - 1}.GetLower().AsByte().StoreUnsafe(ref Unsafe.Add(ref first, {lastRegOffset}));");
+    }
+    else
+    {
+        w.WriteLine($"        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, {lastRegOffset}), v{numRegs - 1});");
+    }
+
+    for (int ri = numRegs - 2; ri >= 0; ri--)
+    {
+        if (ri == 0)
+            w.WriteLine("        Unsafe.WriteUnaligned(ref first, v0);");
+        else
+            w.WriteLine($"        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, {ri * 32}), v{ri});");
+    }
+    w.WriteLine("    }");
+}
+
+void WriteSimdSortMethodDouble(StreamWriter w, int n, List<List<(int A, int B)>> steps, string methodSuffix)
+{
+    int regSize = 4;
+    int numRegs = (n + regSize - 1) / regSize;
+    int lastRegElems = n - (numRegs - 1) * regSize;
+    int lastRegOffset = (numRegs - 1) * 32;
+
+    w.WriteLine($"    [MethodImpl(MethodImplOptions.AggressiveOptimization)]");
+    w.WriteLine($"    private static void {methodSuffix}{n}_double(Span<double> span)");
+    w.WriteLine("    {");
+    w.WriteLine("        ref byte first = ref Unsafe.As<double, byte>(ref MemoryMarshal.GetReference(span));");
+
+    for (int ri = 0; ri < numRegs - 1; ri++)
+    {
+        if (ri == 0)
+            w.WriteLine("        var v0 = Unsafe.ReadUnaligned<Vector256<double>>(ref first);");
+        else
+            w.WriteLine($"        var v{ri} = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, {ri * 32}));");
+    }
+
+    if (lastRegElems == regSize)
+    {
+        w.WriteLine($"        var v{numRegs - 1} = Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, {lastRegOffset}));");
+    }
+    else
+    {
+        int overlapOffset = (n - regSize) * 8;
+        int shift = regSize - lastRegElems;
+        byte control = 0;
+        for (int d = 0; d < 4; d++)
+        {
+            int s = (d + shift) % 4;
+            control |= (byte)(s << (d * 2));
+        }
+        w.WriteLine($"        var v{numRegs - 1} = Avx2.Permute4x64(");
+        w.WriteLine($"            Unsafe.ReadUnaligned<Vector256<double>>(ref Unsafe.Add(ref first, {overlapOffset})),");
+        w.WriteLine($"            0x{control:X2});");
+    }
+
+    int totalSlots = numRegs * regSize;
+
+    for (int si = 0; si < steps.Count; si++)
+    {
+        var step = steps[si];
+        int[] perm = Enumerable.Range(0, totalSlots).ToArray();
+        foreach (var (a, b) in step) { perm[a] = b; perm[b] = a; }
+        bool[] isMax = new bool[totalSlots];
+        foreach (var (a, b) in step) isMax[Math.Max(a, b)] = true;
+
+        string pairStr = string.Join(", ", step.Select(p => $"({p.A},{p.B})"));
+        w.WriteLine();
+        w.WriteLine($"        // Step {si}: {pairStr}");
+        w.WriteLine("        {");
+
+        // Identify active registers
+        var activeRegs = new List<int>();
+        for (int tri = 0; tri < numRegs; tri++)
+        {
+            int baseElem = tri * regSize;
+            bool hasWork = false;
+            for (int lane = 0; lane < regSize; lane++)
+                if (perm[baseElem + lane] != baseElem + lane) { hasWork = true; break; }
+            if (hasWork) activeRegs.Add(tri);
+        }
+
+        // Pass 1: compute all shuffled vectors from unmodified registers
+        foreach (int tri in activeRegs)
+        {
+            int baseElem = tri * regSize;
+            var sourceGroups = new Dictionary<int, List<(int destLane, int srcLane)>>();
+            for (int lane = 0; lane < regSize; lane++)
+            {
+                int srcElem = perm[baseElem + lane];
+                int srcReg = srcElem / regSize;
+                int srcLane = srcElem % regSize;
+                if (!sourceGroups.ContainsKey(srcReg))
+                    sourceGroups[srcReg] = [];
+                sourceGroups[srcReg].Add((lane, srcLane));
+            }
+
+            var sortedSources = sourceGroups.Keys.OrderBy(k => k).ToList();
+
+            if (sortedSources.Count == 1 && sortedSources[0] == tri)
+            {
+                int[] srcLanes = new int[regSize];
+                for (int lane = 0; lane < regSize; lane++)
+                    srcLanes[lane] = perm[baseElem + lane] % regSize;
+                byte ctrl = (byte)(srcLanes[0] | (srcLanes[1] << 2) | (srcLanes[2] << 4) | (srcLanes[3] << 6));
+                w.WriteLine($"            var shuffled{tri} = Avx2.Permute4x64(v{tri}, 0x{ctrl:X2});");
+            }
+            else
+            {
+                foreach (int srcReg in sortedSources)
+                {
+                    int[] srcLanes = new int[regSize];
+                    for (int lane = 0; lane < regSize; lane++)
+                        srcLanes[lane] = lane;
+                    foreach (var (destLane, srcLane) in sourceGroups[srcReg])
+                        srcLanes[destLane] = srcLane;
+                    byte ctrl = (byte)(srcLanes[0] | (srcLanes[1] << 2) | (srcLanes[2] << 4) | (srcLanes[3] << 6));
+                    w.WriteLine($"            var from{tri}_{srcReg} = Avx2.Permute4x64(v{srcReg}, 0x{ctrl:X2});");
+                }
+
+                if (sortedSources.Count == 1)
+                {
+                    w.WriteLine($"            var shuffled{tri} = from{tri}_{sortedSources[0]};");
+                }
+                else
+                {
+                    string prev = $"from{tri}_{sortedSources[0]}";
+                    for (int bi = 1; bi < sortedSources.Count; bi++)
+                    {
+                        int srcReg = sortedSources[bi];
+                        long[] blendMask = new long[regSize];
+                        foreach (var (destLane, _) in sourceGroups[srcReg])
+                            blendMask[destLane] = -1L;
+                        string next = bi < sortedSources.Count - 1 ? $"blend{tri}_{bi}" : $"shuffled{tri}";
+                        w.WriteLine($"            var {next} = Avx.BlendVariable({prev}, from{tri}_{srcReg}, {FmtVec256_Long(blendMask)}.AsDouble());");
+                        prev = next;
+                    }
+                }
+            }
+        }
+
+        // Pass 2: apply min/max/blend using shuffled vectors
+        foreach (int tri in activeRegs)
+        {
+            int baseElem = tri * regSize;
+            long[] maxMask = new long[regSize];
+            for (int lane = 0; lane < regSize; lane++)
+                if (isMax[baseElem + lane]) maxMask[lane] = -1L;
+            w.WriteLine($"            var mins{tri} = Avx.Min(v{tri}, shuffled{tri});");
+            w.WriteLine($"            var maxs{tri} = Avx.Max(v{tri}, shuffled{tri});");
+            w.WriteLine($"            v{tri} = Avx.BlendVariable(mins{tri}, maxs{tri}, {FmtVec256_Long(maxMask)}.AsDouble());");
+        }
+
+        w.WriteLine("        }");
+    }
+
+    w.WriteLine();
+    if (lastRegElems < regSize)
+    {
+        int overlapOffset = (n - regSize) * 8;
+        int shift = regSize - lastRegElems;
+        byte control = 0;
+        for (int d = 0; d < 4; d++)
+        {
+            int s = (d - shift + 4) % 4;
+            control |= (byte)(s << (d * 2));
+        }
+        w.WriteLine($"        Avx2.Permute4x64(v{numRegs - 1}, 0x{control:X2}).AsByte()");
+        w.WriteLine($"            .StoreUnsafe(ref Unsafe.Add(ref first, {overlapOffset}));");
+    }
+    else
+    {
+        w.WriteLine($"        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, {lastRegOffset}), v{numRegs - 1});");
+    }
+
+    for (int ri = numRegs - 2; ri >= 0; ri--)
+    {
+        if (ri == 0)
+            w.WriteLine("        Unsafe.WriteUnaligned(ref first, v0);");
+        else
+            w.WriteLine($"        Unsafe.WriteUnaligned(ref Unsafe.Add(ref first, {ri * 32}), v{ri});");
+    }
+    w.WriteLine("    }");
+}
+
 void WriteSimdFile(StreamWriter w)
 {
     w.Write("""
@@ -866,6 +1203,20 @@ void WriteSimdFile(StreamWriter w)
             w.WriteLine();
             WriteSimdSortMethod64(w, n, steps, typeName);
         }
+    }
+
+    foreach (int n in new[] { 27, 28 })
+    {
+        var steps = GetNetworkSteps(n);
+        w.WriteLine();
+        WriteSimdSortMethodFloat(w, n, steps);
+    }
+
+    foreach (int n in new[] { 27, 28 })
+    {
+        var steps = GetNetworkSteps(n);
+        w.WriteLine();
+        WriteSimdSortMethodDouble(w, n, steps, "SortSimdAvx2_");
     }
 
     w.WriteLine("}");
@@ -1179,6 +1530,7 @@ void WritePublicApi(StreamWriter w, string t)
     bool hasSimd32 = t == "int" || t == "uint";
     bool hasArmSimd32 = t == "int" || t == "uint" || t == "float";
     bool hasSimd64 = t == "long" || t == "ulong" || t == "double";
+    bool hasAvx2Float = t == "float" || t == "double";
 
     w.WriteLine("    /// <summary>");
     w.WriteLine($"    /// Sorts a span of {t} using a sorting network when possible.");
@@ -1215,6 +1567,19 @@ void WritePublicApi(StreamWriter w, string t)
     }
     else if (hasArmSimd32)
     {
+        // float: AVX2 first, then ARM fallback
+        if (hasAvx2Float)
+        {
+            w.WriteLine($"            if (Avx2.IsSupported)");
+            w.WriteLine("            {");
+            w.WriteLine($"                if (n == 27)");
+            w.WriteLine($"                    SortSimd27{suffix}(span);");
+            w.WriteLine("                else");
+            w.WriteLine($"                    SortSimd28{suffix}(span);");
+            w.WriteLine("                return;");
+            w.WriteLine("            }");
+            w.WriteLine();
+        }
         w.WriteLine("            if (AdvSimd.Arm64.IsSupported)");
         w.WriteLine("            {");
         w.WriteLine($"                if (n == 27)");
@@ -1236,6 +1601,19 @@ void WritePublicApi(StreamWriter w, string t)
         w.WriteLine("                return;");
         w.WriteLine("            }");
         w.WriteLine();
+        // double: AVX2 fallback after AVX-512F
+        if (hasAvx2Float)
+        {
+            w.WriteLine("            if (Avx2.IsSupported)");
+            w.WriteLine("            {");
+            w.WriteLine($"                if (n == 27)");
+            w.WriteLine($"                    SortSimdAvx2_27{suffix}(span);");
+            w.WriteLine("                else");
+            w.WriteLine($"                    SortSimdAvx2_28{suffix}(span);");
+            w.WriteLine("                return;");
+            w.WriteLine("            }");
+            w.WriteLine();
+        }
     }
     w.WriteLine($"            ref {t} first = ref MemoryMarshal.GetReference(span);");
     w.WriteLine("            if (n == 27)");


### PR DESCRIPTION
## Summary

Implements AVX2 SIMD sorting for `float` and `double` types at sizes 27/28, closing #27.

### Float (4xVector256<float>, 8 elements each)
- Uses `Avx2.PermuteVar8x32` for intra-register shuffles
- Uses `Avx.BlendVariable` for cross-register gathering
- Uses `Avx.Min`/`Avx.Max` for comparisons
- Dispatch: AVX2 -> ARM AdvSimd -> scalar

### Double (7xVector256<double>, 4 elements each)
- Uses `Avx2.Permute4x64` with compile-time control bytes
- Same blend/min/max pattern for cross-register operations
- Dispatch: AVX-512F -> AVX2 -> scalar

### Benchmark results (Intel i9-9900K, .NET 10)

| Type | ArraySort (27) | NetworkSort (27) | Speedup |
|---|---|---|---|
| float | 1,598 ns | 107 ns | **15x** |
| double | 1,630 ns | 110 ns | **15x** |

### Key design decision
Each SIMD step uses a **two-pass approach**: first compute all shuffled vectors from unmodified registers, then apply min/max/blend updates. This avoids read-after-write hazards when multiple registers reference each other within the same step.

### Changes
- `scripts/generate_unrolled.cs`: Added `WriteSimdSortMethodFloat`, `WriteSimdSortMethodDouble`, format helpers, updated `WriteSimdFile` and `WritePublicApi`
- `SortingNetworks/NetworkSort.Simd.cs`: Regenerated with new float/double SIMD methods
- `SortingNetworks/NetworkSort.cs`: Regenerated with `Avx2.IsSupported` dispatch for float/double
- `README.md`: Updated Design section and benchmark tables for float/double SIMD

All 135 tests pass.

Closes #27