### PR TITLE
Add Linux ARM64 (ubuntu-24.04-arm) to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
GitHub now offers free Linux ARM64 hosted runners for public repos ([discussion](https://github.com/orgs/community/discussions/148648)). This adds `ubuntu-24.04-arm` to the CI test matrix so we run tests and benchmarks on Linux ARM64 as well.

The existing `macos-latest` leg already covers ARM64/NEON SIMD paths, but only on macOS. Adding a Linux ARM64 runner gives us coverage of the AdvSimd code paths on Linux, where runtime behavior and JIT output can differ.

## Benchmark comparison -- ARM64 (Neoverse-N2) vs x64 (EPYC 7763)

Ratio = NetworkSort / ArraySort (lower is better):

| Type | ARM64 Ratio | x64 Ratio | Notes |
|------|-------------|-----------|-------|
| Byte 27 | **0.02** | 0.03 | ~43x faster on both -- SIMD shines with narrow types |
| Char 27 | **0.64** | 0.92 | ARM64 actually wins more here |
| Double 27 | **0.06** | 0.07 | Consistent ~16x win |
| Float 27 | **0.07** | 0.07 | Nearly identical |
| Int 27 | 1.64 | 1.13 | ArraySort faster on both platforms -- not ARM64-specific |

The Int result (NetworkSort slower) is consistent with x64 -- .NET's `Array.Sort` for `int` is already highly optimized. ARM64 just has even faster ArraySort for Int (97ns vs 124ns on x64) while NetworkSort stays roughly the same (~159ns vs ~139ns).

All tests passed on all 4 runners, and the new leg correctly exercises the AdvSimd/NEON paths on Linux.