### PR TITLE
Add nint[] and nuint[] to Sort_NullArray_Throws test

### DIFF
--- a/SortingNetworks.Tests/NetworkSortTests.cs
+++ b/SortingNetworks.Tests/NetworkSortTests.cs
@@ -430,6 +430,8 @@ public class NetworkSortTests
         Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((uint[])null!));
         Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((long[])null!));
         Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((ulong[])null!));
+        Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((nint[])null!));
+        Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((nuint[])null!));
         Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((float[])null!));
         Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((double[])null!));
         Assert.Throws<ArgumentNullException>(() => NetworkSort.Sort((char[])null!));


### PR DESCRIPTION
The `Sort_NullArray_Throws` test covered most primitive types but was missing `nint[]` and `nuint[]`. This adds both to match the existing pattern.