### PR TITLE
Skip identity vectors in ARM64 32-bit SIMD generator

### DIFF
--- a/scripts/generate_unrolled.cs
+++ b/scripts/generate_unrolled.cs
@@ -1394,8 +1394,26 @@ void WriteArmSimdSortMethod32(StreamWriter w, int n, List<List<(int A, int B)>> 
         w.WriteLine("            var tableA = (v0, v1, v2, v3);");
         w.WriteLine("            var tableB = (v4, v5, v6, Vector128<byte>.Zero);");
 
+        // Determine which vectors are identity (all elements map to themselves)
+        bool[] vectorIsIdentity = new bool[7];
         for (int vi = 0; vi < 7; vi++)
         {
+            bool isIdentity = true;
+            for (int ei = 0; ei < 4; ei++)
+            {
+                if (perm[vi * 4 + ei] != vi * 4 + ei)
+                {
+                    isIdentity = false;
+                    break;
+                }
+            }
+            vectorIsIdentity[vi] = isIdentity;
+        }
+
+        for (int vi = 0; vi < 7; vi++)
+        {
+            if (vectorIsIdentity[vi]) continue;
+
             byte[] idxA = new byte[16];
             byte[] idxB = new byte[16];
             bool needsA = false, needsB = false;
@@ -1436,6 +1454,8 @@ void WriteArmSimdSortMethod32(StreamWriter w, int n, List<List<(int A, int B)>> 
 
         for (int vi = 0; vi < 7; vi++)
         {
+            if (vectorIsIdentity[vi]) continue;
+
             byte[] blendMask = new byte[16];
             for (int ei = 0; ei < 4; ei++)
             {


### PR DESCRIPTION
## Summary

When all 4 elements in a vector map to themselves (identity permutation), skip both the TBL/TBX shuffle and the Min/Max/BitwiseSelect blend for that vector.

### What changed
- Only `scripts/generate_unrolled.cs` is modified - the generator now computes `vectorIsIdentity[]` and skips identity vectors in both the shuffle loop and the blend loop
- Two-loop structure is preserved unchanged

### Impact
For the current depth-13 network with 4-element vectors, this optimization **never fires** - every vector always has at least one element participating in a swap. Generated code is unchanged.

This is future-proofing for different network configurations where identity vectors may occur.

### Context
This is one of two optimizations split from #42 to isolate performance impact. Since generated code is identical, this should have zero performance impact - it is a baseline/control PR.

See also: #43 (trivial blend elimination - the one with actual code changes)