### PR TITLE
Remove unused `hasArmSimd32` variable from generator

### DIFF
--- a/scripts/generate_unrolled.cs
+++ b/scripts/generate_unrolled.cs
@@ -1680,7 +1680,6 @@ void WritePublicApi(StreamWriter w, string t)
     bool hasSimd16 = t == "short" || t == "ushort" || t == "char";
     bool hasSimd32 = t == "int" || t == "uint";
     bool hasSimd32_512 = t == "int" || t == "uint" || t == "float";
-    bool hasArmSimd32 = t == "int" || t == "uint" || t == "float";
     bool hasSimd64 = t == "long" || t == "ulong" || t == "double";
     bool hasAvx2Float = t == "float" || t == "double";
 


### PR DESCRIPTION
The `hasArmSimd32` variable in `scripts/generate_unrolled.cs` (line 1683) was defined but never referenced anywhere. ARM dispatch for 32-bit types is already handled within the `hasSimd32_512` branch.

**Changes:**
- Removed the dead `hasArmSimd32` variable definition from the generator script

**Verification:**
- Re-ran the generator — all generated files are identical (confirming the variable was truly unused)
- All 161 tests pass