### PR TITLE
Add optional DisassemblyDiagnoser via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      disassembly:
+        description: 'Enable DisassemblyDiagnoser for benchmarks'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   build:
@@ -54,6 +61,8 @@ jobs:
 
       - name: Benchmarks
         shell: bash
+        env:
+          DISASSEMBLY_DIAGNOSER: ${{ inputs.disassembly && '1' || '0' }}
         run: |
           dotnet run --project SortingNetworks.Benchmarks -c Release -- --filter '*' --exporters GitHub
           for f in BenchmarkDotNet.Artifacts/results/*-report-github.md; do
@@ -67,6 +76,17 @@ jobs:
             cat "$f" >> benchmark-summary.md
             echo "" >> benchmark-summary.md
           done
+          if [ "$DISASSEMBLY_DIAGNOSER" = "1" ]; then
+            for f in BenchmarkDotNet.Artifacts/results/*-asm.md; do
+              [ -f "$f" ] || continue
+              name=$(basename "$f" -asm.md)
+              name=${name##*.}
+              echo "# Disassembly: $name" >> disassembly-summary.md
+              echo "" >> disassembly-summary.md
+              cat "$f" >> disassembly-summary.md
+              echo "" >> disassembly-summary.md
+            done
+          fi
 
       - name: Upload benchmark summary
         uses: actions/upload-artifact@v7
@@ -74,6 +94,16 @@ jobs:
         with:
           name: benchmark-summary-${{ matrix.os }}
           path: benchmark-summary.md
+          if-no-files-found: ignore
+
+      - name: Upload disassembly
+        uses: actions/upload-artifact@v7
+        if: inputs.disassembly
+        with:
+          name: disassembly-${{ matrix.os }}
+          path: |
+            disassembly-summary.md
+            BenchmarkDotNet.Artifacts/results/*-asm.md
           if-no-files-found: ignore
 
   summarize:

--- a/SortingNetworks.Benchmarks/Program.cs
+++ b/SortingNetworks.Benchmarks/Program.cs
@@ -1,3 +1,12 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Running;
 
-BenchmarkSwitcher.FromAssembly(typeof(SortingNetworks.Benchmarks.IntSortingBenchmarks).Assembly).Run(args);
+IConfig? config = null;
+if (Environment.GetEnvironmentVariable("DISASSEMBLY_DIAGNOSER") == "1")
+{
+    config = DefaultConfig.Instance
+        .AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(maxDepth: 3)));
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(SortingNetworks.Benchmarks.IntSortingBenchmarks).Assembly).Run(args, config);


### PR DESCRIPTION
When the CI workflow is triggered manually with **Enable DisassemblyDiagnoser** checked, sets `DISASSEMBLY_DIAGNOSER=1` which causes BenchmarkDotNet to emit JIT disassembly (`maxDepth: 3`) for each benchmark method.

## What it produces

- Per-method `*-asm.md` files with the actual JIT-compiled native code
- A merged `disassembly-summary.md` uploaded as an artifact per OS
- On ARM64 runners (`macos-latest`, `ubuntu-24.04-arm`): shows NEON/AdvSimd codegen
- On x86 runners (`ubuntu-latest`, `windows-latest`): shows AVX2/AVX-512 codegen

## How to use

1. Go to **Actions → CI → Run workflow**
2. Check **Enable DisassemblyDiagnoser**
3. Download the `disassembly-*` artifacts after the run completes

## Why

This helps analyze the ARM64 `int[]` sorting network SIMD path to identify optimization opportunities — register spilling, constant rematerialization, TBL/TBX instruction counts, etc. Normal runs are unaffected (the env var defaults to `0`).