### PR TITLE
Skip DisassemblyDiagnoser on macOS (unsupported by BDN)

### DIFF
--- a/SortingNetworks.Benchmarks/Program.cs
+++ b/SortingNetworks.Benchmarks/Program.cs
@@ -1,9 +1,11 @@
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Running;
+using System.Runtime.InteropServices;
 
 IConfig? config = null;
-if (Environment.GetEnvironmentVariable("DISASSEMBLY_DIAGNOSER") == "1")
+if (Environment.GetEnvironmentVariable("DISASSEMBLY_DIAGNOSER") == "1"
+    && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
 {
     config = DefaultConfig.Instance
         .AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(maxDepth: 3)));


### PR DESCRIPTION
BenchmarkDotNet's `DisassemblyDiagnoser` only supports Windows and Linux. On macOS it aborts the entire benchmark run with:

> Only Windows and Linux are supported in DisassemblyDiagnoser without Mono. Current OS is macOS 15.7.4

This adds an `OSPlatform.OSX` check so macOS runs benchmarks normally while `ubuntu-24.04-arm` still captures the ARM64 NEON disassembly we need.