### PR TITLE
Update test count in README from 135 to 161

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ dotnet run scripts/generate_unrolled.cs
 - **SortingNetworks** -- class library (future NuGet package)
 - **SortingNetworks.Tests** -- xUnit correctness tests covering lengths 27-28
   across all 13 primitive types, plus string via the specialized `Sort(string[])`
-  overload, with stress tests using 100 random seeds (135 tests)
+  overload, with stress tests using 100 random seeds (161 tests)
 - **SortingNetworks.Benchmarks** -- BenchmarkDotNet benchmarks comparing
   `NetworkSort.Sort` vs `Array.Sort` for sizes 27 and 28 across all primitive
   types


### PR DESCRIPTION
## Summary

Updated the test count in the README Projects section from 135 to 161, verified with `dotnet test`.

## Benchmark review

Reviewed all benchmark numbers in the README against available data:

- **x86 (Intel Core i9-9900K, AVX2)**: All numbers match `results/benchmark-results.md` exactly ✅
- **x86 AVX-512F (AMD EPYC 9V74)**: Current ubuntu-latest runner now uses AMD EPYC 7763 (no AVX-512), so these numbers can't be validated from the latest CI run. The README properly labels them as from "AMD EPYC 9V74" so they remain accurate as documented. ✅
- **ARM64 (Apple M1)**: Current macOS CI results are noisy (high error bars on several types) but all ratios and speedup patterns are consistent with README values ✅
- **int detailed results (both x86 and ARM64)**: All ratios and percentages verified ✅
- **Test count**: Was 135, actual count is **161** — updated ✅