### PR TITLE
Source generator: AVX2 fallback for 16-bit types (short/ushort/char)

### DIFF
--- a/SortingNetworks.Generators/SimdX86Emitter.cs
+++ b/SortingNetworks.Generators/SimdX86Emitter.cs
@@ -43,6 +43,30 @@ namespace SortingNetworks.Generators
         }
 
         /// <summary>
+        /// Returns true if this type/size can use an AVX2 fallback path (currently 16-bit types, sizes 8-16).
+        /// </summary>
+        internal static bool CanEmitAvx2Fallback(string typeName, int size)
+        {
+            return ElementSize(typeName) == 2 && size >= 8 && size <= 16;
+        }
+
+        /// <summary>
+        /// Returns the AVX2 fallback guard condition string.
+        /// </summary>
+        internal static string GetAvx2FallbackGuardCondition()
+        {
+            return "System.Runtime.Intrinsics.X86.Avx2.IsSupported";
+        }
+
+        /// <summary>
+        /// Emits an AVX2 fallback SIMD sort method for 16-bit types.
+        /// </summary>
+        internal static (string MethodSource, string DispatchCode) EmitAvx2Fallback(int size, string typeName, List<List<(int A, int B)>> steps)
+        {
+            return EmitShortAvx2(size, typeName, steps);
+        }
+
+        /// <summary>
         /// Emits a SIMD sort method + dispatch from the public Sort method.
         /// Returns the SIMD method source and the dispatch check to insert into Sort.
         /// </summary>
@@ -293,6 +317,124 @@ namespace SortingNetworks.Generators
                 $"            if (System.Runtime.Intrinsics.X86.Avx512BW.IsSupported)\n" +
                 $"            {{\n" +
                 $"                SortSimd{size}{suffix}(span);\n" +
+                $"                return;\n" +
+                $"            }}\n";
+
+            return (sb.ToString(), dispatchSb);
+        }
+
+        // --- 16-bit types: single Vector256 with AVX2 fallback (sizes 8-16) ---
+
+        private static (string, string) EmitShortAvx2(int size, string typeName, List<List<(int A, int B)>> steps)
+        {
+            // AVX2: single Vector256<ushort> for ≤ 16 elements
+            if (size > 16) return ("", "");
+
+            var sb = new StringBuilder();
+            string suffix = $"_{typeName}";
+            int totalBytes = size * 2;
+
+            sb.AppendLine($"        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]");
+            sb.AppendLine($"        private static void SortSimdAvx2{size}{suffix}(System.Span<{typeName}> span)");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            ref byte first = ref System.Runtime.CompilerServices.Unsafe.As<{typeName}, byte>(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span));");
+
+            // Load into Vector256<ushort>
+            if (size <= 8)
+            {
+                // 8 elements = 16 bytes → lower Vector128
+                sb.AppendLine("            var lo = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector128<byte>>(ref first);");
+                sb.AppendLine("            var vec = System.Runtime.Intrinsics.Vector256.Create(lo, System.Runtime.Intrinsics.Vector128<byte>.Zero).AsUInt16();");
+            }
+            else if (size == 16)
+            {
+                // 16 elements = 32 bytes → full Vector256
+                sb.AppendLine("            var vec = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector256<byte>>(ref first).AsUInt16();");
+            }
+            else
+            {
+                // 9-15 elements: load lower 128 bits + overlapping upper with shift
+                int hiReadOffset = totalBytes - 16;
+                int shiftBytes = 32 - totalBytes;
+                sb.AppendLine("            var lo = System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector128<byte>>(ref first);");
+                sb.AppendLine($"            var hi = System.Runtime.Intrinsics.Vector128.Shuffle(");
+                sb.AppendLine($"                System.Runtime.CompilerServices.Unsafe.ReadUnaligned<System.Runtime.Intrinsics.Vector128<byte>>(ref System.Runtime.CompilerServices.Unsafe.Add(ref first, {hiReadOffset})),");
+                // Build shift-right mask
+                var shiftMask = new byte[16];
+                for (int i = 0; i < 16; i++)
+                {
+                    int src = i + shiftBytes;
+                    shiftMask[i] = src < 16 ? (byte)src : (byte)0x80;
+                }
+                sb.AppendLine($"                {FmtVec128(shiftMask)});");
+                sb.AppendLine("            var vec = System.Runtime.Intrinsics.Vector256.Create(lo, hi).AsUInt16();");
+            }
+
+            // Emit each step
+            for (int si = 0; si < steps.Count; si++)
+            {
+                var step = steps[si];
+
+                // Build ushort permutation for 16 elements
+                ushort[] ushortPerm = new ushort[16];
+                for (int i = 0; i < 16; i++) ushortPerm[i] = (ushort)i;
+                foreach (var (a, b) in step) { ushortPerm[a] = (ushort)b; ushortPerm[b] = (ushort)a; }
+
+                // Convert to byte permutation for Vector256.Shuffle on bytes
+                byte[] bytePerm = new byte[32];
+                for (int i = 0; i < 16; i++)
+                {
+                    bytePerm[i * 2] = (byte)(ushortPerm[i] * 2);
+                    bytePerm[i * 2 + 1] = (byte)(ushortPerm[i] * 2 + 1);
+                }
+
+                // Build ushort blend mask
+                ushort[] blend = new ushort[16];
+                foreach (var (a, b) in step) blend[Math.Max(a, b)] = 0xFFFF;
+
+                string pairStr = string.Join(", ", step.Select(p => $"({p.A},{p.B})"));
+
+                sb.AppendLine();
+                sb.AppendLine($"            // Step {si}: {pairStr}");
+                sb.AppendLine("            {");
+                sb.AppendLine($"                var shuffled = System.Runtime.Intrinsics.Vector256.Shuffle(vec.AsByte(), {FmtVec256(bytePerm)}).AsUInt16();");
+                sb.AppendLine($"                var mins = {MinExprShortAvx2(typeName, "vec", "shuffled")};");
+                sb.AppendLine($"                var maxs = {MaxExprShortAvx2(typeName, "vec", "shuffled")};");
+                sb.AppendLine($"                vec = System.Runtime.Intrinsics.Vector256.ConditionalSelect({FmtVec256UShort(blend)}, maxs, mins);");
+                sb.AppendLine("            }");
+            }
+
+            // Store results
+            sb.AppendLine();
+            if (size <= 8)
+            {
+                sb.AppendLine("            vec.AsByte().GetLower().StoreUnsafe(ref first);");
+            }
+            else if (size == 16)
+            {
+                sb.AppendLine("            vec.AsByte().StoreUnsafe(ref first);");
+            }
+            else
+            {
+                // Partial store: write upper first (with shift), then lower (overwrites overlap)
+                int hiReadOffset = totalBytes - 16;
+                int shiftBytes = 32 - totalBytes;
+                var storeMask = new byte[16];
+                for (int i = 0; i < 16; i++)
+                {
+                    int src = i - shiftBytes;
+                    storeMask[i] = src >= 0 ? (byte)src : (byte)0x80;
+                }
+                sb.AppendLine($"            System.Runtime.Intrinsics.Vector128.Shuffle(vec.AsByte().GetUpper(), {FmtVec128(storeMask)})");
+                sb.AppendLine($"                .StoreUnsafe(ref System.Runtime.CompilerServices.Unsafe.Add(ref first, {hiReadOffset}));");
+                sb.AppendLine("            vec.AsByte().GetLower().StoreUnsafe(ref first);");
+            }
+            sb.AppendLine("        }");
+
+            string dispatchSb =
+                $"            if (System.Runtime.Intrinsics.X86.Avx2.IsSupported)\n" +
+                $"            {{\n" +
+                $"                SortSimdAvx2{size}{suffix}(span);\n" +
                 $"                return;\n" +
                 $"            }}\n";
 
@@ -791,6 +933,9 @@ namespace SortingNetworks.Generators
         private static string FmtVec512UShort(ushort[] values) =>
             $"System.Runtime.Intrinsics.Vector512.Create((ushort){string.Join(", ", values.Select(v => $"0x{v:X4}"))})";
 
+        private static string FmtVec256UShort(ushort[] values) =>
+            $"System.Runtime.Intrinsics.Vector256.Create((ushort){string.Join(", ", values.Select(v => $"0x{v:X4}"))})";
+
         private static string FmtVec512Long(long[] values) =>
             $"System.Runtime.Intrinsics.Vector512.Create({string.Join(", ", values.Select(v => $"{v}L"))})";
 
@@ -813,6 +958,16 @@ namespace SortingNetworks.Generators
             typeName == "short"
                 ? $"System.Runtime.Intrinsics.X86.Avx512BW.Max({v}.AsInt16(), {s}.AsInt16()).AsUInt16()"
                 : $"System.Runtime.Intrinsics.X86.Avx512BW.Max({v}, {s})";
+
+        private static string MinExprShortAvx2(string typeName, string v, string s) =>
+            typeName == "short"
+                ? $"System.Runtime.Intrinsics.Vector256.Min({v}.AsInt16(), {s}.AsInt16()).AsUInt16()"
+                : $"System.Runtime.Intrinsics.Vector256.Min({v}, {s})";
+
+        private static string MaxExprShortAvx2(string typeName, string v, string s) =>
+            typeName == "short"
+                ? $"System.Runtime.Intrinsics.Vector256.Max({v}.AsInt16(), {s}.AsInt16()).AsUInt16()"
+                : $"System.Runtime.Intrinsics.Vector256.Max({v}, {s})";
 
         private static string MinExprInt(string typeName, string v, string s)
         {

--- a/SortingNetworks.Generators/SortingNetworkGenerator.cs
+++ b/SortingNetworks.Generators/SortingNetworkGenerator.cs
@@ -125,7 +125,8 @@ namespace SortingNetworks.Generators
             bool needsSimdUsing = false;
             foreach (var request in validRequests)
             {
-                if (SimdX86Emitter.CanEmit(request.TypeName, request.Size))
+                if (SimdX86Emitter.CanEmit(request.TypeName, request.Size) ||
+                    SimdX86Emitter.CanEmitAvx2Fallback(request.TypeName, request.Size))
                 {
                     needsSimdUsing = true;
                     break;
@@ -161,6 +162,7 @@ namespace SortingNetworks.Generators
             // Pre-compute networks and SIMD info for each request
             var networksByRequest = new Dictionary<string, int[]>();
             var simdStepsByRequest = new Dictionary<string, List<List<(int A, int B)>>>();
+            var avx2FallbackStepsByRequest = new Dictionary<string, List<List<(int A, int B)>>>();
             foreach (var request in validRequests)
             {
                 var key = $"{request.TypeName}_{request.Size}";
@@ -175,6 +177,11 @@ namespace SortingNetworks.Generators
                 {
                     simdStepsByRequest[key] = SimdX86Emitter.DecomposeIntoSteps(network);
                 }
+
+                if (SimdX86Emitter.CanEmitAvx2Fallback(request.TypeName, request.Size))
+                {
+                    avx2FallbackStepsByRequest[key] = SimdX86Emitter.DecomposeIntoSteps(network);
+                }
             }
 
             // Emit one public Sort overload per type with flattened dispatch
@@ -187,11 +194,14 @@ namespace SortingNetworks.Generators
 
                 // Check which sizes have SIMD support
                 var simdSizes = new List<NetworkRequest>();
+                var avx2FallbackSizes = new List<NetworkRequest>();
                 foreach (var request in sizes)
                 {
                     var key = $"{request.TypeName}_{request.Size}";
                     if (simdStepsByRequest.ContainsKey(key))
                         simdSizes.Add(request);
+                    if (avx2FallbackStepsByRequest.ContainsKey(key))
+                        avx2FallbackSizes.Add(request);
                 }
 
                 // Determine the SIMD guard condition string
@@ -235,6 +245,32 @@ namespace SortingNetworks.Generators
                     sb.AppendLine("                }");
                 }
 
+                // AVX2 fallback dispatch block (for 16-bit types that have AVX-512 primary + AVX2 fallback)
+                if (avx2FallbackSizes.Count > 0)
+                {
+                    string avx2Guard = SimdX86Emitter.GetAvx2FallbackGuardCondition();
+                    // Use "else if" when there's a primary SIMD block above, plain "if" otherwise
+                    string prefix = (simdGuard != null && simdSizes.Count > 0) ? "else if" : "if";
+                    sb.AppendLine($"                {prefix} ({avx2Guard})");
+                    sb.AppendLine("                {");
+                    if (avx2FallbackSizes.Count == 1)
+                    {
+                        sb.AppendLine($"                    if (n == {avx2FallbackSizes[0].Size})");
+                        sb.AppendLine("                    {");
+                        sb.AppendLine($"                        SortSimdAvx2{avx2FallbackSizes[0].Size}_{typeName}(span);");
+                        sb.AppendLine("                        return;");
+                        sb.AppendLine("                    }");
+                    }
+                    else
+                    {
+                        foreach (var request in avx2FallbackSizes)
+                        {
+                            sb.AppendLine($"                    if (n == {request.Size}) {{ SortSimdAvx2{request.Size}_{typeName}(span); return; }}");
+                        }
+                    }
+                    sb.AppendLine("                }");
+                }
+
                 // Scalar fallback: get ref and dispatch
                 sb.AppendLine($"                ref {typeName} first = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span);");
                 if (sizes.Count == 1)
@@ -268,6 +304,17 @@ namespace SortingNetworks.Generators
                     if (!string.IsNullOrEmpty(simdMethod))
                     {
                         sb.AppendLine(simdMethod);
+                        sb.AppendLine();
+                    }
+                }
+
+                // Emit AVX2 fallback SIMD method if applicable
+                if (avx2FallbackStepsByRequest.TryGetValue(key, out var avx2Steps))
+                {
+                    var (avx2Method, _) = SimdX86Emitter.EmitAvx2Fallback(request.Size, request.TypeName, avx2Steps);
+                    if (!string.IsNullOrEmpty(avx2Method))
+                    {
+                        sb.AppendLine(avx2Method);
                         sb.AppendLine();
                     }
                 }

--- a/SortingNetworks.Tests/GeneratedSortTests.cs
+++ b/SortingNetworks.Tests/GeneratedSortTests.cs
@@ -102,4 +102,89 @@ public class GeneratedSortTests
         var arr = new int[5];
         Assert.Throws<ArgumentException>(() => GeneratedSorters.Sort(arr));
     }
+
+    [Fact]
+    public void Sort8_UShort_MatchesArraySort()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 8).Select(_ => (ushort)rng.Next(0, 65536)).ToArray();
+            var expected = (ushort[])input.Clone();
+            Array.Sort(expected);
+
+            var actual = (ushort[])input.Clone();
+            GeneratedSorters.Sort(actual.AsSpan());
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void Sort16_UShort_MatchesArraySort()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 16).Select(_ => (ushort)rng.Next(0, 65536)).ToArray();
+            var expected = (ushort[])input.Clone();
+            Array.Sort(expected);
+
+            var actual = (ushort[])input.Clone();
+            GeneratedSorters.Sort(actual.AsSpan());
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void Sort8_Short_MatchesArraySort()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 8).Select(_ => (short)rng.Next(-32768, 32768)).ToArray();
+            var expected = (short[])input.Clone();
+            Array.Sort(expected);
+
+            var actual = (short[])input.Clone();
+            GeneratedSorters.Sort(actual.AsSpan());
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void Sort16_Short_MatchesArraySort()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 16).Select(_ => (short)rng.Next(-32768, 32768)).ToArray();
+            var expected = (short[])input.Clone();
+            Array.Sort(expected);
+
+            var actual = (short[])input.Clone();
+            GeneratedSorters.Sort(actual.AsSpan());
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void Sort12_UShort_MatchesArraySort()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 12).Select(_ => (ushort)rng.Next(0, 65536)).ToArray();
+            var expected = (ushort[])input.Clone();
+            Array.Sort(expected);
+
+            var actual = (ushort[])input.Clone();
+            GeneratedSorters.Sort(actual.AsSpan());
+
+            Assert.Equal(expected, actual);
+        }
+    }
 }

--- a/SortingNetworks.Tests/GeneratedSorters.cs
+++ b/SortingNetworks.Tests/GeneratedSorters.cs
@@ -13,4 +13,9 @@ namespace SortingNetworks.Tests;
 [SortingNetwork(16, typeof(double))]
 [SortingNetwork(16, typeof(byte))]
 [SortingNetwork(16, typeof(long))]
+[SortingNetwork(8, typeof(ushort))]
+[SortingNetwork(16, typeof(ushort))]
+[SortingNetwork(8, typeof(short))]
+[SortingNetwork(16, typeof(short))]
+[SortingNetwork(12, typeof(ushort))]
 partial class GeneratedSorters { }

--- a/SortingNetworks.Tests/GeneratorTests.cs
+++ b/SortingNetworks.Tests/GeneratorTests.cs
@@ -216,6 +216,11 @@ public partial class MySorter { }
     [InlineData(32, "int")]
     [InlineData(8, "byte")]
     [InlineData(16, "byte")]
+    [InlineData(8, "ushort")]
+    [InlineData(16, "ushort")]
+    [InlineData(8, "short")]
+    [InlineData(16, "short")]
+    [InlineData(12, "ushort")]
     public void SimdCode_Compiles(int size, string typeName)
     {
         var source = $@"
@@ -261,5 +266,39 @@ public partial class MySorter { }
         System.IO.File.WriteAllText(
             System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sort16_int_generated.cs"),
             generatedSource);
+    }
+
+    [Theory]
+    [InlineData(8, "ushort")]
+    [InlineData(16, "ushort")]
+    [InlineData(12, "ushort")]
+    [InlineData(8, "short")]
+    [InlineData(16, "short")]
+    public void SimdCode_16Bit_HasAvx2Fallback(int size, string typeName)
+    {
+        var source = $@"
+using SortingNetworks;
+
+[SortingNetwork({size}, typeof({typeName}))]
+public partial class MySorter {{ }}
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        // Verify both AVX-512 and AVX2 methods were generated
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains($"SortSimd{size}_{typeName}") && s.Contains($"SortSimdAvx2{size}_{typeName}"));
+        Assert.NotNull(generatedSource);
+
+        // Verify dispatch cascades from AVX-512 BW to AVX2
+        Assert.Contains("Avx512BW.IsSupported", generatedSource);
+        Assert.Contains("Avx2.IsSupported", generatedSource);
     }
 }


### PR DESCRIPTION
Picks up work from #73, resolves merge conflicts with main, and merges the AVX2 fallback SIMD code generation for 16-bit types.

## Changes

Adds an AVX2 fallback SIMD path for 16-bit types (`short`, `ushort`, `char`) in the source generator. Previously, these types only had AVX-512 BW SIMD acceleration — systems without AVX-512 would fall back to scalar code. Now there's a middle tier:

```
AVX-512 BW → AVX2 fallback → scalar
```

### New files
- **`SimdX86Emitter.cs`** — New `EmitShortAvx2()` method generates AVX2 SIMD sort methods using `Vector256<ushort>` with byte-level shuffles for sizes 8–16

### Modified files
- **`SortingNetworkGenerator.cs`** — Adds AVX2 fallback detection, dispatch generation (`else if (Avx2.IsSupported)`), and method emission
- **`GeneratedSorters.cs`** — New `[SortingNetwork]` attributes for `ushort`/`short` at sizes 8, 12, 16
- **`GeneratedSortTests.cs`** — 5 new runtime correctness tests (50 random seeds each)
- **`GeneratorTests.cs`** — Compile-time verification tests + `SimdCode_16Bit_HasAvx2Fallback` theory

### Merge conflict resolution
`GeneratedSortTests.cs` had a conflict between main's `Sort_NullArray_Throws`/`Sort_ArrayOverload_MatchesArraySort` tests (from #70) and this PR's 16-bit type tests. Resolved by keeping both.

All 251 tests pass.

Closes #73