### PR TITLE
Add sample project to verify NuGet package end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Pack
         run: dotnet pack -c Release --no-build
 
+      - name: Verify NuGet package
+        run: >
+          dotnet run --project samples/SortingNetworks.Sample
+          -p:RestoreAdditionalProjectSources=$(pwd)/SortingNetworks/bin/Release
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Verify NuGet package
         run: >
           dotnet run --project samples/SortingNetworks.Sample
-          -p:RestoreAdditionalProjectSources=$(pwd)/SortingNetworks/bin/Release
+          -p:RestoreSources=$(pwd)/SortingNetworks/bin/Release
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/samples/SortingNetworks.Sample/Program.cs
+++ b/samples/SortingNetworks.Sample/Program.cs
@@ -1,0 +1,20 @@
+using SortingNetworks;
+
+var data = new int[] {
+    27, 26, 25, 24, 23, 22, 21, 20, 19,
+    18, 17, 16, 15, 14, 13, 12, 11, 10,
+    9, 8, 7, 6, 5, 4, 3, 2, 1,
+};
+MySorter.Sort(data);
+
+var expected = Enumerable.Range(1, 27).ToArray();
+if (!data.SequenceEqual(expected))
+{
+    Console.Error.WriteLine("Sort failed!");
+    return 1;
+}
+Console.WriteLine("Sort succeeded!");
+return 0;
+
+[SortingNetwork(27, typeof(int))]
+partial class MySorter { }

--- a/samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj
+++ b/samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SortingNetworks" Version="1.0.0" />
+    <PackageReference Include="SortingNetworks" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj
+++ b/samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SortingNetworks" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds a minimal sample project that consumes the locally-built `.nupkg` to verify the NuGet package works correctly from a consumer's perspective.

## Changes

- **`samples/SortingNetworks.Sample/Program.cs`** — Console app that uses `[SortingNetwork(27, typeof(int))]` to generate a sorter, sorts 27→1 descending, and verifies the result matches `1→27`
- **`samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj`** — References `SortingNetworks` v1.0.0 as a `PackageReference`
- **`.github/workflows/ci.yml`** — Adds a "Verify NuGet package" step after `dotnet pack` that runs the sample using `RestoreAdditionalProjectSources` to point at the local package output

## What this verifies

- The `.nupkg` contains both `SortingNetworks.dll` (attribute) and `SortingNetworks.Generators.dll` (analyzer)
- The source generator activates correctly from the package
- The generated sort method compiles and produces correct output
- Exit code 0 confirms everything works

Closes #96