### PR TITLE
Add OnFallback API for configurable fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,40 @@ MySorter.Sort(array);
 MySorter.Sort(data, Comparer<int>.Create((a, b) => b.CompareTo(a)));
 ```
 
+### Handling unsupported sizes
+
+By default, calling `Sort` with a span length that doesn't match any
+`[SortingNetwork]` size throws `ArgumentException`. To handle unsupported
+sizes gracefully, define a static `OnFallback` method in your partial class:
+
+```csharp
+[SortingNetwork(27, typeof(int))]
+partial class MySorter
+{
+    static void OnFallback(Span<int> span)
+    {
+        span.Sort(); // or log, throw a custom exception, etc.
+    }
+
+    // Optional: comparer-aware fallback
+    static void OnFallback(Span<int> span, IComparer<int> comparer)
+    {
+        int[] temp = span.ToArray();
+        Array.Sort(temp, comparer);
+        temp.CopyTo(span);
+    }
+}
+
+MySorter.Sort(data);           // size 27 → sorting network
+MySorter.Sort(otherData);      // any other size → OnFallback
+```
+
+- If no `OnFallback` is defined, unsupported sizes throw (same as before).
+- The 1-parameter overload handles `Sort(Span<T>)` and `Sort(T[])`.
+- The 2-parameter overload handles `Sort(Span<T>, IComparer<T>)` and
+  `Sort(T[], IComparer<T>)`. If only the 1-parameter overload is defined,
+  the comparer path still throws.
+
 The source generator emits optimized sort methods with:
 - **Scalar unrolled** compare-and-swap for all sizes/types
 - **x86 SIMD** (AVX2, AVX-512) when the type and size fit in SIMD registers

--- a/SortingNetworks.Generators/SortingNetworkGenerator.cs
+++ b/SortingNetworks.Generators/SortingNetworkGenerator.cs
@@ -92,6 +92,27 @@ namespace SortingNetworks.Generators
             if (attributes.Count == 0)
                 return null;
 
+            // Detect OnFallback methods: static void OnFallback(Span<T>)
+            var fallbackTypes = new HashSet<string>();
+            foreach (var member in classSymbol.GetMembers("OnFallback"))
+            {
+                if (member is IMethodSymbol method &&
+                    method.IsStatic &&
+                    method.ReturnsVoid &&
+                    method.Parameters.Length == 1)
+                {
+                    var paramType = method.Parameters[0].Type;
+                    if (paramType is INamedTypeSymbol namedType &&
+                        namedType.OriginalDefinition.ToDisplayString() == "System.Span<T>")
+                    {
+                        var typeArg = namedType.TypeArguments[0];
+                        var typeName = GetKeywordName(typeArg.SpecialType)
+                            ?? typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                        fallbackTypes.Add(typeName);
+                    }
+                }
+            }
+
             var namespaceName = classSymbol.ContainingNamespace.IsGlobalNamespace
                 ? null
                 : classSymbol.ContainingNamespace.ToDisplayString();
@@ -99,7 +120,8 @@ namespace SortingNetworks.Generators
             return new GenerationInfo(
                 classSymbol.Name,
                 namespaceName,
-                attributes.ToArray());
+                attributes.ToArray(),
+                fallbackTypes);
         }
 
         private static void Execute(SourceProductionContext context, ImmutableArray<GenerationInfo?> infos)
@@ -530,7 +552,14 @@ namespace SortingNetworks.Generators
                 }
                 sb.AppendLine("                return;");
                 sb.AppendLine("            }");
-                sb.AppendLine($"            throw new System.ArgumentException($\"No sorting network for length {{n}}. Supported lengths: {string.Join(", ", sizes.Select(s => s.Size.ToString()))}.\", nameof(span));");
+                if (info.FallbackTypes.Contains(typeName))
+                {
+                    sb.AppendLine($"            OnFallback(span);");
+                }
+                else
+                {
+                    sb.AppendLine($"            throw new System.ArgumentException($\"No sorting network for length {{n}}. Supported lengths: {string.Join(", ", sizes.Select(s => s.Size.ToString()))}.\", nameof(span));");
+                }
                 sb.AppendLine("        }");
                 sb.AppendLine();
 
@@ -570,7 +599,14 @@ namespace SortingNetworks.Generators
                     sb.AppendLine("            }");
                 }
 
-                sb.AppendLine($"            throw new System.ArgumentException($\"No sorting network for length {{n}}. Supported lengths: {string.Join(", ", sizes.Select(s => s.Size.ToString()))}.\", nameof(span));");
+                if (info.FallbackTypes.Contains(typeName))
+                {
+                    sb.AppendLine($"            OnFallback(span);");
+                }
+                else
+                {
+                    sb.AppendLine($"            throw new System.ArgumentException($\"No sorting network for length {{n}}. Supported lengths: {string.Join(", ", sizes.Select(s => s.Size.ToString()))}.\", nameof(span));");
+                }
                 sb.AppendLine("        }");
                 sb.AppendLine();
 
@@ -730,12 +766,14 @@ namespace SortingNetworks.Generators
             public string ClassName { get; }
             public string? Namespace { get; }
             public NetworkRequest[] Requests { get; }
+            public HashSet<string> FallbackTypes { get; }
 
-            public GenerationInfo(string className, string? ns, NetworkRequest[] requests)
+            public GenerationInfo(string className, string? ns, NetworkRequest[] requests, HashSet<string> fallbackTypes)
             {
                 ClassName = className;
                 Namespace = ns;
                 Requests = requests;
+                FallbackTypes = fallbackTypes;
             }
         }
 

--- a/SortingNetworks.Generators/SortingNetworkGenerator.cs
+++ b/SortingNetworks.Generators/SortingNetworkGenerator.cs
@@ -92,23 +92,41 @@ namespace SortingNetworks.Generators
             if (attributes.Count == 0)
                 return null;
 
-            // Detect OnFallback methods: static void OnFallback(Span<T>)
+            // Detect OnFallback methods: static void OnFallback(Span<T>) and OnFallback(Span<T>, IComparer<T>)
             var fallbackTypes = new HashSet<string>();
+            var fallbackTypesWithComparer = new HashSet<string>();
             foreach (var member in classSymbol.GetMembers("OnFallback"))
             {
                 if (member is IMethodSymbol method &&
                     method.IsStatic &&
-                    method.ReturnsVoid &&
-                    method.Parameters.Length == 1)
+                    method.ReturnsVoid)
                 {
-                    var paramType = method.Parameters[0].Type;
-                    if (paramType is INamedTypeSymbol namedType &&
-                        namedType.OriginalDefinition.ToDisplayString() == "System.Span<T>")
+                    if (method.Parameters.Length == 1)
                     {
-                        var typeArg = namedType.TypeArguments[0];
-                        var typeName = GetKeywordName(typeArg.SpecialType)
-                            ?? typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                        fallbackTypes.Add(typeName);
+                        var paramType = method.Parameters[0].Type;
+                        if (paramType is INamedTypeSymbol namedType &&
+                            namedType.OriginalDefinition.ToDisplayString() == "System.Span<T>")
+                        {
+                            var typeArg = namedType.TypeArguments[0];
+                            var typeName = GetKeywordName(typeArg.SpecialType)
+                                ?? typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                            fallbackTypes.Add(typeName);
+                        }
+                    }
+                    else if (method.Parameters.Length == 2)
+                    {
+                        var spanParam = method.Parameters[0].Type;
+                        var comparerParam = method.Parameters[1].Type;
+                        if (spanParam is INamedTypeSymbol spanType &&
+                            spanType.OriginalDefinition.ToDisplayString() == "System.Span<T>" &&
+                            comparerParam is INamedTypeSymbol comparerType &&
+                            comparerType.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IComparer<T>")
+                        {
+                            var typeArg = spanType.TypeArguments[0];
+                            var typeName = GetKeywordName(typeArg.SpecialType)
+                                ?? typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                            fallbackTypesWithComparer.Add(typeName);
+                        }
                     }
                 }
             }
@@ -121,7 +139,8 @@ namespace SortingNetworks.Generators
                 classSymbol.Name,
                 namespaceName,
                 attributes.ToArray(),
-                fallbackTypes);
+                fallbackTypes,
+                fallbackTypesWithComparer);
         }
 
         private static void Execute(SourceProductionContext context, ImmutableArray<GenerationInfo?> infos)
@@ -599,9 +618,9 @@ namespace SortingNetworks.Generators
                     sb.AppendLine("            }");
                 }
 
-                if (info.FallbackTypes.Contains(typeName))
+                if (info.FallbackTypesWithComparer.Contains(typeName))
                 {
-                    sb.AppendLine($"            OnFallback(span);");
+                    sb.AppendLine($"            OnFallback(span, comparer);");
                 }
                 else
                 {
@@ -767,13 +786,15 @@ namespace SortingNetworks.Generators
             public string? Namespace { get; }
             public NetworkRequest[] Requests { get; }
             public HashSet<string> FallbackTypes { get; }
+            public HashSet<string> FallbackTypesWithComparer { get; }
 
-            public GenerationInfo(string className, string? ns, NetworkRequest[] requests, HashSet<string> fallbackTypes)
+            public GenerationInfo(string className, string? ns, NetworkRequest[] requests, HashSet<string> fallbackTypes, HashSet<string> fallbackTypesWithComparer)
             {
                 ClassName = className;
                 Namespace = ns;
                 Requests = requests;
                 FallbackTypes = fallbackTypes;
+                FallbackTypesWithComparer = fallbackTypesWithComparer;
             }
         }
 

--- a/SortingNetworks.Tests/FallbackSorter.cs
+++ b/SortingNetworks.Tests/FallbackSorter.cs
@@ -1,0 +1,18 @@
+using SortingNetworks;
+
+namespace SortingNetworks.Tests;
+
+[SortingNetwork(4, typeof(int))]
+[SortingNetwork(4, typeof(double))]
+partial class FallbackSorter
+{
+    static void OnFallback(Span<int> span)
+    {
+        span.Sort();
+    }
+
+    static void OnFallback(Span<double> span)
+    {
+        span.Sort();
+    }
+}

--- a/SortingNetworks.Tests/FallbackSorter.cs
+++ b/SortingNetworks.Tests/FallbackSorter.cs
@@ -6,13 +6,33 @@ namespace SortingNetworks.Tests;
 [SortingNetwork(4, typeof(double))]
 partial class FallbackSorter
 {
+    internal static int FallbackCallCount;
+
     static void OnFallback(Span<int> span)
     {
+        FallbackCallCount++;
         span.Sort();
+    }
+
+    static void OnFallback(Span<int> span, System.Collections.Generic.IComparer<int> comparer)
+    {
+        FallbackCallCount++;
+        int[] temp = span.ToArray();
+        Array.Sort(temp, comparer);
+        temp.CopyTo(span);
     }
 
     static void OnFallback(Span<double> span)
     {
+        FallbackCallCount++;
         span.Sort();
+    }
+
+    static void OnFallback(Span<double> span, System.Collections.Generic.IComparer<double> comparer)
+    {
+        FallbackCallCount++;
+        double[] temp = span.ToArray();
+        Array.Sort(temp, comparer);
+        temp.CopyTo(span);
     }
 }

--- a/SortingNetworks.Tests/GeneratedSortTests.cs
+++ b/SortingNetworks.Tests/GeneratedSortTests.cs
@@ -1233,4 +1233,82 @@ public class GeneratedSortTests
         GeneratedSorters.Sort(input.AsSpan(), null);
         Assert.Equal(expected, input);
     }
+
+    // --- OnFallback tests ---
+
+    [Fact]
+    public void Sort_OnFallback_SortsUnsupportedSize()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 10).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        FallbackSorter.Sort(input.AsSpan());
+
+        Assert.Equal(expected, input);
+    }
+
+    [Fact]
+    public void Sort_OnFallback_SupportedSize_UsesNetwork()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var rng = new Random(seed);
+            var input = Enumerable.Range(0, 4).Select(_ => rng.Next(-1000, 1000)).ToArray();
+            var expected = (int[])input.Clone();
+            Array.Sort(expected);
+
+            var actual = (int[])input.Clone();
+            FallbackSorter.Sort(actual.AsSpan());
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void Sort_OnFallback_Double_SortsUnsupportedSize()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 10).Select(_ => rng.NextDouble() * 200 - 100).ToArray();
+        var expected = (double[])input.Clone();
+        Array.Sort(expected);
+
+        FallbackSorter.Sort(input.AsSpan());
+
+        Assert.Equal(expected, input);
+    }
+
+    [Fact]
+    public void Sort_OnFallback_ArrayOverload_SortsUnsupportedSize()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 10).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        FallbackSorter.Sort(input);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Fact]
+    public void Sort_OnFallback_WithComparer_SortsUnsupportedSize()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 10).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected);
+
+        FallbackSorter.Sort(input.AsSpan(), Comparer<int>.Default);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Fact]
+    public void Sort_WithoutOnFallback_StillThrows()
+    {
+        var arr = new int[5];
+        Assert.Throws<ArgumentException>(() => GeneratedSorters.Sort(arr));
+    }
 }

--- a/SortingNetworks.Tests/GeneratedSortTests.cs
+++ b/SortingNetworks.Tests/GeneratedSortTests.cs
@@ -1252,6 +1252,8 @@ public class GeneratedSortTests
     [Fact]
     public void Sort_OnFallback_SupportedSize_UsesNetwork()
     {
+        FallbackSorter.FallbackCallCount = 0;
+
         for (int seed = 0; seed < 50; seed++)
         {
             var rng = new Random(seed);
@@ -1264,6 +1266,8 @@ public class GeneratedSortTests
 
             Assert.Equal(expected, actual);
         }
+
+        Assert.Equal(0, FallbackSorter.FallbackCallCount);
     }
 
     [Fact]
@@ -1301,6 +1305,19 @@ public class GeneratedSortTests
         Array.Sort(expected);
 
         FallbackSorter.Sort(input.AsSpan(), Comparer<int>.Default);
+
+        Assert.Equal(expected, input);
+    }
+
+    [Fact]
+    public void Sort_OnFallback_WithCustomComparer_SortsUnsupportedSize()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 10).Select(_ => rng.Next(-1000, 1000)).ToArray();
+        var expected = (int[])input.Clone();
+        Array.Sort(expected, Comparer<int>.Create((a, b) => b.CompareTo(a)));
+
+        FallbackSorter.Sort(input.AsSpan(), Comparer<int>.Create((a, b) => b.CompareTo(a)));
 
         Assert.Equal(expected, input);
     }

--- a/SortingNetworks.Tests/GeneratorTests.cs
+++ b/SortingNetworks.Tests/GeneratorTests.cs
@@ -556,8 +556,15 @@ public partial class MySorter
             .Select(t => t.GetText().ToString())
             .FirstOrDefault(s => s.Contains("OnFallback(span)"));
         Assert.NotNull(generatedSource);
-        // Should NOT contain the throw for int
-        Assert.DoesNotContain("throw new System.ArgumentException", generatedSource);
+
+        // Extract the span Sort method block (before the array overload)
+        var spanSortStart = generatedSource.IndexOf("public static void Sort(System.Span<int> span)");
+        var arraySortStart = generatedSource.IndexOf("public static void Sort(int[] array)");
+        Assert.True(spanSortStart >= 0 && arraySortStart > spanSortStart);
+        var spanSortBlock = generatedSource.Substring(spanSortStart, arraySortStart - spanSortStart);
+
+        Assert.Contains("OnFallback(span)", spanSortBlock);
+        Assert.DoesNotContain("throw new System.ArgumentException", spanSortBlock);
     }
 
     [Fact]
@@ -616,8 +623,104 @@ public partial class MySorter
             .Select(t => t.GetText().ToString())
             .FirstOrDefault(s => s.Contains("Sort4"));
         Assert.NotNull(generatedSource);
-        // int should have OnFallback, double should still throw
+
+        // Extract span Sort blocks only (before their array overloads)
+        var intSpanSortIndex = generatedSource.IndexOf("public static void Sort(System.Span<int> span)");
+        var intArraySortIndex = generatedSource.IndexOf("public static void Sort(int[] array)");
+        var doubleSpanSortIndex = generatedSource.IndexOf("public static void Sort(System.Span<double> span)");
+        var doubleArraySortIndex = generatedSource.IndexOf("public static void Sort(double[] array)");
+        Assert.True(intSpanSortIndex >= 0, "Expected int span Sort method");
+        Assert.True(doubleSpanSortIndex >= 0, "Expected double span Sort method");
+
+        var intSpanSortBlock = generatedSource.Substring(intSpanSortIndex, intArraySortIndex - intSpanSortIndex);
+        var doubleSpanSortBlock = generatedSource.Substring(doubleSpanSortIndex, doubleArraySortIndex - doubleSpanSortIndex);
+
+        Assert.Contains("OnFallback(span)", intSpanSortBlock);
+        Assert.DoesNotContain("throw new System.ArgumentException", intSpanSortBlock);
+
+        Assert.Contains("throw new System.ArgumentException", doubleSpanSortBlock);
+        Assert.DoesNotContain("OnFallback", doubleSpanSortBlock);
+    }
+
+    [Fact]
+    public void OnFallback_WithComparer_GeneratesComparerCall()
+    {
+        var source = @"
+using SortingNetworks;
+using System;
+using System.Collections.Generic;
+
+[SortingNetwork(4, typeof(int))]
+public partial class MySorter
+{
+    static void OnFallback(Span<int> span)
+    {
+        span.Sort();
+    }
+    static void OnFallback(Span<int> span, IComparer<int> comparer)
+    {
+        int[] temp = span.ToArray();
+        Array.Sort(temp, comparer);
+        temp.CopyTo(span);
+    }
+}
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains("Sort4"));
+        Assert.NotNull(generatedSource);
+
+        // Span overload should call OnFallback(span)
         Assert.Contains("OnFallback(span)", generatedSource);
+        // Comparer overload should call OnFallback(span, comparer)
+        Assert.Contains("OnFallback(span, comparer)", generatedSource);
+        // No throws since both overloads have fallbacks
+        Assert.DoesNotContain("throw new System.ArgumentException", generatedSource);
+    }
+
+    [Fact]
+    public void OnFallback_SpanOnly_ComparerStillThrows()
+    {
+        var source = @"
+using SortingNetworks;
+using System;
+
+[SortingNetwork(4, typeof(int))]
+public partial class MySorter
+{
+    static void OnFallback(Span<int> span)
+    {
+        span.Sort();
+    }
+}
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains("Sort4"));
+        Assert.NotNull(generatedSource);
+
+        // Span Sort calls OnFallback
+        Assert.Contains("OnFallback(span)", generatedSource);
+        // Comparer Sort still throws (no 2-param OnFallback defined)
         Assert.Contains("throw new System.ArgumentException", generatedSource);
+        Assert.DoesNotContain("OnFallback(span, comparer)", generatedSource);
     }
 }

--- a/SortingNetworks.Tests/GeneratorTests.cs
+++ b/SortingNetworks.Tests/GeneratorTests.cs
@@ -526,4 +526,98 @@ public partial class MySorter { }
             .FirstOrDefault(s => s.Contains("IComparer<int>") && s.Contains("IComparer<double>"));
         Assert.NotNull(generatedSource);
     }
+
+    [Fact]
+    public void OnFallback_GeneratesCallInsteadOfThrow()
+    {
+        var source = @"
+using SortingNetworks;
+using System;
+
+[SortingNetwork(4, typeof(int))]
+public partial class MySorter
+{
+    static void OnFallback(Span<int> span)
+    {
+        span.Sort();
+    }
+}
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains("OnFallback(span)"));
+        Assert.NotNull(generatedSource);
+        // Should NOT contain the throw for int
+        Assert.DoesNotContain("throw new System.ArgumentException", generatedSource);
+    }
+
+    [Fact]
+    public void WithoutOnFallback_GeneratesThrow()
+    {
+        var source = @"
+using SortingNetworks;
+
+[SortingNetwork(4, typeof(int))]
+public partial class MySorter { }
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains("Sort4"));
+        Assert.NotNull(generatedSource);
+        Assert.Contains("throw new System.ArgumentException", generatedSource);
+        Assert.DoesNotContain("OnFallback", generatedSource);
+    }
+
+    [Fact]
+    public void OnFallback_MultipleTypes_OnlyFallbackForDefinedType()
+    {
+        var source = @"
+using SortingNetworks;
+using System;
+
+[SortingNetwork(4, typeof(int))]
+[SortingNetwork(4, typeof(double))]
+public partial class MySorter
+{
+    static void OnFallback(Span<int> span)
+    {
+        span.Sort();
+    }
+}
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains("Sort4"));
+        Assert.NotNull(generatedSource);
+        // int should have OnFallback, double should still throw
+        Assert.Contains("OnFallback(span)", generatedSource);
+        Assert.Contains("throw new System.ArgumentException", generatedSource);
+    }
 }


### PR DESCRIPTION
Closes #95

## Design

The source generator detects `static void OnFallback(Span<T>)` methods on the partial class. When present, the generated `Sort` method calls `OnFallback` instead of throwing `ArgumentException` for unsupported sizes.

Without `OnFallback` defined, behavior is **unchanged** (throws).

### Usage

```csharp
[SortingNetwork(4, typeof(int))]
partial class MySorter
{
    static void OnFallback(Span<int> span)
    {
        span.Sort(); // or log, throw custom exception, etc.
    }
}

// Supported size -> uses sorting network
MySorter.Sort(new int[4]);

// Unsupported size -> calls OnFallback instead of throwing
MySorter.Sort(new int[10]);
```

### Why this approach

- No new attributes, enums, or attribute properties
- Zero-cost when unused -- default throw behavior is identical to today
- Maximum flexibility -- users can sort, log, throw custom exceptions
- Sidesteps TFM issues (user picks the sort API available to them)
- Per-type granularity via overloads: `OnFallback(Span<int>)`, `OnFallback(Span<double>)`

### Changes

- **Generator**: Inspects class members for `OnFallback` methods; emits call instead of throw when found (both span and comparer overloads)
- **Tests**: 4 generator tests (call generated, throw preserved, per-type behavior) + 5 runtime tests (unsupported size sorts correctly, supported size uses network, array/comparer overloads)