### PR TITLE
Fix nint/nuint scalar sort perf by delegating to fixed-size types

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,8 @@ For other types without SIMD-optimized `Array.Sort` in the BCL:
 | short | 1,719 ns | 154 ns | **11x** |
 | ushort | 1,589 ns | 154 ns | **10x** |
 | long | 1,696 ns | 147 ns | **12x** |
-| nint | 1,867 ns | 166 ns | **11x** |
-| nuint | 1,742 ns | 175 ns | **10x** |
+| nint | 1,854 ns | 155 ns | **12x** |
+| nuint | 1,780 ns | 142 ns | **13x** |
 | string | 941 ns | 678 ns | **1.4x** |
 
 > **Note:** These results are from an AMD EPYC 9V74 on GitHub Actions
@@ -490,6 +490,8 @@ speedup over `Array.Sort` as on x86:
 |---|---|---|---|
 | double | 1,461 ns | 110 ns | **13x** |
 | long | 1,122 ns | 100 ns | **11x** |
+| nint | 1,133 ns | 101 ns | **11x** |
+| nuint | 1,135 ns | 101 ns | **11x** |
 
 ### ARM64 (Ampere Neoverse-N2, AdvSimd/NEON)
 
@@ -508,6 +510,15 @@ Apple Silicon. The TBL1 optimization for intra-register shuffles is critical her
 > **Note:** Without the TBL1 optimization, `char` size 27 was 135 ns — slower
 > than ArraySort (97 ns). The optimization reduced it to 68 ns, a **2x
 > improvement** that made GeneratedSort 1.6x faster than ArraySort.
+
+#### Other types (scalar unrolled network)
+
+| Type | ArraySort (27) | GeneratedSort (27) | Speedup |
+|---|---|---|---|
+| long | 2,059 ns | 139 ns | **15x** |
+| nint | 2,081 ns | 147 ns | **14x** |
+| nuint | 2,083 ns | 142 ns | **15x** |
+| double | 2,442 ns | 149 ns | **16x** |
 
 ### int detailed results (AVX2 SIMD)
 

--- a/README.md
+++ b/README.md
@@ -305,12 +305,13 @@ For `double`, AVX-512F SIMD is emitted on x86 when available (four `Vector512`
 registers). On CPUs without AVX-512F, an AVX2 fallback uses seven
 `Vector256<double>` registers (4 elements each) with `Permute4x64` shuffles.
 
-For `nint` and `nuint`, the generated code dispatches to the corresponding fixed-size
-integer sort via `MemoryMarshal.Cast` when SIMD is available for the target type.
-On 64-bit platforms with AVX-512, `nint`/`nuint` dispatch to `long`/`ulong` to
-use AVX-512F SIMD. On 32-bit platforms, they dispatch to `int`/`uint`. When no
-SIMD path exists for the target type (e.g., ARM64 or AVX2-only x86 for 64-bit),
-the scalar unrolled network is used directly to avoid dispatch overhead.
+For `nint` and `nuint`, the generated code delegates to the corresponding fixed-size
+integer sort (`int`/`uint` on 32-bit, `long`/`ulong` on 64-bit) for both SIMD and
+scalar paths. The SIMD path uses `MemoryMarshal.Cast` to reinterpret the span,
+while the scalar path uses `Unsafe.As` to reinterpret the element reference —
+matching the pattern used by dotnet/runtime's `SpanHelpers` for native-sized types.
+This ensures optimal JIT codegen on all platforms by avoiding separate `nint`/`nuint`
+sort methods.
 
 ## Benchmarks
 

--- a/SortingNetworks.Generators/SortingNetworkGenerator.cs
+++ b/SortingNetworks.Generators/SortingNetworkGenerator.cs
@@ -620,16 +620,59 @@ namespace SortingNetworks.Generators
                 }
 
                 // Scalar fallback: get ref and dispatch
-                sb.AppendLine($"                ref {typeName} first = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span);");
-                if (sizes.Count == 1)
+                // For nint/nuint, delegate to the fixed-size type's scalar sort via Unsafe.As
+                // for optimal JIT codegen — matches the pattern used by dotnet/runtime SpanHelpers.
+                var scalarDelegateTypes = GetNativeIntDelegateTypes(typeName);
+                if (scalarDelegateTypes != null)
                 {
-                    sb.AppendLine($"                Sort{sizes[0].Size}(ref first);");
+                    var (scalarType32, scalarType64) = scalarDelegateTypes.Value;
+                    var scalarTypeName64 = GetKeywordName(scalarType64)!;
+                    var scalarTypeName32 = GetKeywordName(scalarType32)!;
+
+                    sb.AppendLine($"                if ({typeName}.Size == 8)");
+                    sb.AppendLine("                {");
+                    sb.AppendLine($"                    ref {scalarTypeName64} first = ref System.Runtime.CompilerServices.Unsafe.As<{typeName}, {scalarTypeName64}>(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span));");
+                    if (sizes.Count == 1)
+                    {
+                        sb.AppendLine($"                    Sort{sizes[0].Size}(ref first);");
+                    }
+                    else
+                    {
+                        foreach (var request in sizes)
+                        {
+                            sb.AppendLine($"                    if (n == {request.Size}) {{ Sort{request.Size}(ref first); return; }}");
+                        }
+                    }
+                    sb.AppendLine("                }");
+                    sb.AppendLine($"                if ({typeName}.Size == 4)");
+                    sb.AppendLine("                {");
+                    sb.AppendLine($"                    ref {scalarTypeName32} first = ref System.Runtime.CompilerServices.Unsafe.As<{typeName}, {scalarTypeName32}>(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span));");
+                    if (sizes.Count == 1)
+                    {
+                        sb.AppendLine($"                    Sort{sizes[0].Size}(ref first);");
+                    }
+                    else
+                    {
+                        foreach (var request in sizes)
+                        {
+                            sb.AppendLine($"                    if (n == {request.Size}) {{ Sort{request.Size}(ref first); return; }}");
+                        }
+                    }
+                    sb.AppendLine("                }");
                 }
                 else
                 {
-                    foreach (var request in sizes)
+                    sb.AppendLine($"                ref {typeName} first = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(span);");
+                    if (sizes.Count == 1)
                     {
-                        sb.AppendLine($"                if (n == {request.Size}) {{ Sort{request.Size}(ref first); return; }}");
+                        sb.AppendLine($"                Sort{sizes[0].Size}(ref first);");
+                    }
+                    else
+                    {
+                        foreach (var request in sizes)
+                        {
+                            sb.AppendLine($"                if (n == {request.Size}) {{ Sort{request.Size}(ref first); return; }}");
+                        }
                     }
                 }
                 sb.AppendLine("                return;");
@@ -704,6 +747,7 @@ namespace SortingNetworks.Generators
 
             // Emit private SIMD methods and scalar Sort{size} methods
             var emittedSimdMethods = new HashSet<string>();
+            var emittedScalarMethods = new HashSet<string>();
             foreach (var request in validRequests)
             {
                 var key = $"{request.TypeName}_{request.Size}";
@@ -803,16 +847,40 @@ namespace SortingNetworks.Generators
                     }
                 }
 
-                // Emit scalar method (takes ref T first, matches library pattern) — skip for non-comparable custom types
-                if (!request.IsCustomType)
+                // Emit scalar method (takes ref T first, matches library pattern)
+                // For nint/nuint, emit the delegate type's scalar method instead
+                var nativeDelegate = GetNativeIntDelegateTypes(request.TypeName);
+                if (nativeDelegate != null)
                 {
-                    sb.Append(ScalarEmitter.EmitSortMethod(request.Size, request.TypeName, network));
-                    sb.AppendLine();
+                    var (delegateType32, delegateType64) = nativeDelegate.Value;
+                    foreach (var delegateSpecialType in new[] { delegateType32, delegateType64 })
+                    {
+                        var delegateTypeName = GetKeywordName(delegateSpecialType)!;
+                        var scalarKey = $"Sort{request.Size}_{delegateTypeName}";
+                        if (emittedScalarMethods.Add(scalarKey))
+                        {
+                            sb.Append(ScalarEmitter.EmitSortMethod(request.Size, delegateTypeName, network));
+                            sb.AppendLine();
+                        }
+                    }
+                }
+                else if (!request.IsCustomType)
+                {
+                    var scalarKey = $"Sort{request.Size}_{request.TypeName}";
+                    if (emittedScalarMethods.Add(scalarKey))
+                    {
+                        sb.Append(ScalarEmitter.EmitSortMethod(request.Size, request.TypeName, network));
+                        sb.AppendLine();
+                    }
                 }
                 else if (request.IsComparable)
                 {
-                    sb.Append(ScalarEmitter.EmitSortMethod(request.Size, request.TypeName, network, useCompareTo: true));
-                    sb.AppendLine();
+                    var scalarKey = $"Sort{request.Size}_{request.TypeName}";
+                    if (emittedScalarMethods.Add(scalarKey))
+                    {
+                        sb.Append(ScalarEmitter.EmitSortMethod(request.Size, request.TypeName, network, useCompareTo: true));
+                        sb.AppendLine();
+                    }
                 }
             }
 

--- a/SortingNetworks.Tests/GeneratorTests.cs
+++ b/SortingNetworks.Tests/GeneratorTests.cs
@@ -835,4 +835,42 @@ public partial class MySorter { }
             .FirstOrDefault(s => s.Contains("Sort(System.Span<int> span)") && s.Contains("IComparer<global::MyRecord>"));
         Assert.NotNull(generatedSource);
     }
+
+    [Theory]
+    [InlineData("nint", "long", "int")]
+    [InlineData("nuint", "ulong", "uint")]
+    public void NativeInt_ScalarFallback_DelegatesToFixedSizeType(string nativeType, string type64, string type32)
+    {
+        var source = $@"
+using SortingNetworks;
+
+[SortingNetwork(16, typeof({nativeType}))]
+public partial class MySorter {{ }}
+";
+        var compilation = SourceGeneratorDriver.CreateCompilation(source);
+        var (result, updatedCompilation) = SourceGeneratorDriver.RunGeneratorWithCompilation(compilation);
+
+        var errors = result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+
+        var compilationErrors = SourceGeneratorDriver.GetErrors(updatedCompilation);
+        Assert.Empty(compilationErrors);
+
+        var generatedSource = result.GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .FirstOrDefault(s => s.Contains("Sort16"));
+        Assert.NotNull(generatedSource);
+
+        // Scalar fallback should delegate to the fixed-size type via Unsafe.As
+        Assert.Contains($"Unsafe.As<{nativeType}, {type64}>", generatedSource);
+        Assert.Contains($"Unsafe.As<{nativeType}, {type32}>", generatedSource);
+        Assert.Contains($"Sort16(ref first)", generatedSource);
+
+        // Should NOT have a scalar Sort16 method with the native type
+        Assert.DoesNotContain($"private static void Sort16(ref {nativeType} first)", generatedSource);
+
+        // Should have scalar Sort16 methods for both delegate types
+        Assert.Contains($"private static void Sort16(ref {type64} first)", generatedSource);
+        Assert.Contains($"private static void Sort16(ref {type32} first)", generatedSource);
+    }
 }


### PR DESCRIPTION
Fixes #92

## Problem

`GeneratedSort` was slower than `ArraySort` for `nint`/`nuint` on some platforms (Ubuntu ARM, Ubuntu x86 AVX-512) because the scalar fallback path generated separate `Sort{N}(ref nint first)` methods. The JIT doesn't optimize `nint`/`nuint` scalar comparisons as well as `int`/`long` on certain microarchitectures.

## Solution

Delegate `nint`/`nuint` scalar sorting to fixed-size types (`int`/`uint` on 32-bit, `long`/`ulong` on 64-bit) using `Unsafe.As<nint, long>(ref first)` — matching the pattern used by dotnet/runtime's `SpanHelpers` for native-sized types. The SIMD path already delegated via `MemoryMarshal.Cast`; this fix extends the same approach to the scalar fallback.

### Changes

- **SortingNetworkGenerator.cs**: Scalar fallback dispatch for `nint`/`nuint` now uses `Unsafe.As` to delegate to the fixed-size type's sort method. Scalar method emission generates delegate type methods instead of `nint`/`nuint` methods, with `emittedScalarMethods` deduplication to avoid conflicts when both `nint` and `long` are registered at the same size.
- **GeneratorTests.cs**: Added `NativeInt_ScalarFallback_DelegatesToFixedSizeType` test verifying the delegation pattern for both `nint` and `nuint`.
- **README.md**: Updated nint/nuint design section and benchmark numbers.

## CI Benchmark Results (size 27)

All platforms show GeneratedSort consistently **11-16x faster** than ArraySort for `nint`/`nuint`. No regressions at any size.

| Platform | Type | ArraySort | GeneratedSort | Speedup |
|---|---|---|---|---|
| Ubuntu ARM (Neoverse-N2) | nint | 2,081 ns | 147 ns | **14x** |
| Ubuntu ARM (Neoverse-N2) | nuint | 2,083 ns | 142 ns | **15x** |
| Ubuntu x86 (AMD EPYC 9V74, AVX-512) | nint | 1,854 ns | 155 ns | **12x** |
| Ubuntu x86 (AMD EPYC 9V74, AVX-512) | nuint | 1,780 ns | 142 ns | **13x** |
| Windows (AMD EPYC 7763) | nint | 2,559 ns | 163 ns | **16x** |
| Windows (AMD EPYC 7763) | nuint | 1,866 ns | 166 ns | **11x** |
| macOS (Apple M1) | nint | 1,133 ns | 101 ns | **11x** |
| macOS (Apple M1) | nuint | 1,135 ns | 101 ns | **11x** |

Main vs PR comparison at size 27 shows no measurable difference — the SIMD dispatch path was already delegating via `MemoryMarshal.Cast` for sizes 23-32. The scalar fix primarily ensures correctness/consistency and protects against platforms where the SIMD path isn't available (e.g., future configurations).
