### PR TITLE
Add PublicApi analyzer to SortingNetworks class library

### DIFF
--- a/SortingNetworks/PublicAPI.Shipped.txt
+++ b/SortingNetworks/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/SortingNetworks/PublicAPI.Unshipped.txt
+++ b/SortingNetworks/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+#nullable enable
+SortingNetworks.SortingNetworkAttribute
+SortingNetworks.SortingNetworkAttribute.ElementType.get -> System.Type!
+SortingNetworks.SortingNetworkAttribute.Size.get -> int
+SortingNetworks.SortingNetworkAttribute.SortingNetworkAttribute(int size, System.Type! elementType) -> void

--- a/SortingNetworks/SortingNetworks.csproj
+++ b/SortingNetworks/SortingNetworks.csproj
@@ -12,6 +12,10 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- Build the generator project (for packing), but don't reference its output -->
   <ItemGroup>
     <ProjectReference Include="..\SortingNetworks.Generators\SortingNetworks.Generators.csproj"


### PR DESCRIPTION
Track the public API surface of the SortingNetworks class library so that accidental breaking changes are caught at build time, matching the setup used in [jonathanpeppers/dotnes](https://github.com/jonathanpeppers/dotnes).

**What changed:**

- Added `Microsoft.CodeAnalysis.PublicApiAnalyzers` 3.3.4 as a `PrivateAssets="all"` dependency
- Created `PublicAPI.Shipped.txt` (empty -- nothing shipped yet)
- Created `PublicAPI.Unshipped.txt` with all current public APIs (`SortingNetworkAttribute`, its constructor, and its two properties)

The build passes clean with 0 warnings and 0 errors.