### PR TITLE
Use span.Sort(comparer.Compare) in fallback examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ partial class MySorter
     // Optional: comparer-aware fallback
     static void OnFallback(Span<int> span, IComparer<int> comparer)
     {
-        int[] temp = span.ToArray();
-        Array.Sort(temp, comparer);
-        temp.CopyTo(span);
+        span.Sort(comparer.Compare);
     }
 }
 

--- a/SortingNetworks.Tests/FallbackSorter.cs
+++ b/SortingNetworks.Tests/FallbackSorter.cs
@@ -17,9 +17,7 @@ partial class FallbackSorter
     static void OnFallback(Span<int> span, System.Collections.Generic.IComparer<int> comparer)
     {
         FallbackCallCount++;
-        int[] temp = span.ToArray();
-        Array.Sort(temp, comparer);
-        temp.CopyTo(span);
+        span.Sort(comparer.Compare);
     }
 
     static void OnFallback(Span<double> span)
@@ -31,8 +29,6 @@ partial class FallbackSorter
     static void OnFallback(Span<double> span, System.Collections.Generic.IComparer<double> comparer)
     {
         FallbackCallCount++;
-        double[] temp = span.ToArray();
-        Array.Sort(temp, comparer);
-        temp.CopyTo(span);
+        span.Sort(comparer.Compare);
     }
 }


### PR DESCRIPTION
The comparer-aware `OnFallback` example in the README copies to a temporary array (`span.ToArray()`, `Array.Sort`, `CopyTo`) just to sort with an `IComparer<T>`. Since `MemoryExtensions.Sort<T>(Span<T>, Comparison<T>)` is available, we can use `span.Sort(comparer.Compare)` instead -- zero allocations, one line.

Updated the README example and the matching `FallbackSorter.cs` test helper to use the simpler pattern. All fallback tests pass.