### PR TITLE
Add Version, PackageTags, and Copyright for NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <Version>0.1.0</Version>
+    <Copyright>Copyright (c) Jonathan Peppers</Copyright>
   </PropertyGroup>
 </Project>

--- a/SortingNetworks/SortingNetworks.csproj
+++ b/SortingNetworks/SortingNetworks.csproj
@@ -6,6 +6,7 @@
     <Description>Source generator for sorting-network-based sorting of small arrays, including depth-13 networks for 27 and 28 channels from arXiv:2511.04107.</Description>
     <Authors>Jonathan Peppers</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>sorting sorting-network source-generator simd performance</PackageTags>
     <PackageProjectUrl>https://github.com/jonathanpeppers/SortingNetworks</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jonathanpeppers/SortingNetworks</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Prepares the NuGet package metadata for an initial 0.1.0 release.

- **Version** set to `0.1.0` in `Directory.Build.props` so it applies to all projects
- **Copyright** added in `Directory.Build.props`
- **PackageTags** added in `SortingNetworks.csproj` (`sorting`, `sorting-network`, `source-generator`, `simd`, `performance`) to improve discoverability on nuget.org

Verified the resulting `.nupkg` contains all expected metadata.