### PR TITLE
Rename NuGet PackageId to `SortingNetworks.SourceGen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and arbitrary types can be sorted via an `IComparer<T>` overload.
 
 ## Usage
 
-Add the `SortingNetworks` NuGet package, then decorate a `partial class` with
+Add the `SortingNetworks.SourceGen` NuGet package, then decorate a `partial class` with
 `[SortingNetwork(size, typeof(T))]` for each size/type combination you need.
 
 > **Target framework:** The generated SIMD code uses `System.Runtime.Intrinsics`
@@ -622,7 +622,7 @@ dotnet run --project SortingNetworks.Benchmarks -c Release -- --filter *
 
 ## Projects
 
-- **SortingNetworks** -- NuGet package containing the `SortingNetworkAttribute`
+- **SortingNetworks** -- NuGet package (`SortingNetworks.SourceGen`) containing the `SortingNetworkAttribute`
   and bundled source generator
 - **SortingNetworks.Generators** -- Roslyn incremental source generator that
   emits optimized sorting network code (scalar + SIMD)

--- a/SortingNetworks/SortingNetworks.csproj
+++ b/SortingNetworks/SortingNetworks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>SortingNetworks</PackageId>
+    <PackageId>SortingNetworks.SourceGen</PackageId>
     <Description>Source generator for sorting-network-based sorting of small arrays, including depth-13 networks for 27 and 28 channels from arXiv:2511.04107.</Description>
     <Authors>Jonathan Peppers</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj
+++ b/samples/SortingNetworks.Sample/SortingNetworks.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SortingNetworks" Version="*" />
+    <PackageReference Include="SortingNetworks.SourceGen" Version="*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The PackageId `SortingNetworks` is [already taken on nuget.org](https://www.nuget.org/packages/SortingNetworks) by [petarpetrovt/sorting-networks](https://github.com/petarpetrovt/sorting-networks). This renames the PackageId to `SortingNetworks.SourceGen` to avoid the conflict.

### Changes
- **SortingNetworks.csproj** — `PackageId` → `SortingNetworks.SourceGen`
- **samples/SortingNetworks.Sample.csproj** — updated `PackageReference` to match
- **README.md** — updated NuGet package name references