### PR TITLE
Ship public APIs and bump version to 0.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Copyright>Copyright (c) Jonathan Peppers</Copyright>
   </PropertyGroup>
 </Project>

--- a/SortingNetworks/PublicAPI.Shipped.txt
+++ b/SortingNetworks/PublicAPI.Shipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+SortingNetworks.SortingNetworkAttribute
+SortingNetworks.SortingNetworkAttribute.ElementType.get -> System.Type!
+SortingNetworks.SortingNetworkAttribute.Size.get -> int
+SortingNetworks.SortingNetworkAttribute.SortingNetworkAttribute(int size, System.Type! elementType) -> void

--- a/SortingNetworks/PublicAPI.Unshipped.txt
+++ b/SortingNetworks/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 #nullable enable
-SortingNetworks.SortingNetworkAttribute
-SortingNetworks.SortingNetworkAttribute.ElementType.get -> System.Type!
-SortingNetworks.SortingNetworkAttribute.Size.get -> int
-SortingNetworks.SortingNetworkAttribute.SortingNetworkAttribute(int size, System.Type! elementType) -> void


### PR DESCRIPTION
Moves all entries from `PublicAPI.Unshipped.txt` to `PublicAPI.Shipped.txt` and bumps the package version from 0.1.0 to 0.1.1 in `Directory.Build.props`.

### Changes

- **PublicAPI.Shipped.txt** -- added the four `SortingNetworkAttribute` API entries
- **PublicAPI.Unshipped.txt** -- cleared (only the `#nullable enable` header remains)
- **Directory.Build.props** -- `Version` updated from `0.1.0` to `0.1.1`